### PR TITLE
Mention "everything" in .desktop Keywords

### DIFF
--- a/data/fsearch.desktop.in.in
+++ b/data/fsearch.desktop.in.in
@@ -7,5 +7,5 @@ Icon=system-search
 TryExec=@PACKAGE@
 Exec=@PACKAGE@
 Categories=GTK;Utility;Core;
-Keywords=search;fsearch;files;find;tool;
+Keywords=search;fsearch;files;find;tool;everything;
 StartupNotify=true


### PR DESCRIPTION
So that searching for it in Ubuntu Dash / GNOME Activities returns fsearch. Useful for someone who'd forgot the name of the app but would remember it's like Everything.