### PR TITLE
Added option to context menu to copy filepath

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -117,3 +117,19 @@ clipboard_copy_file_list (GList* file_list, guint32 copy)
     clipboard_file_list = file_list;
     clipboard_action = copy ? GDK_ACTION_COPY : GDK_ACTION_MOVE;
 }
+
+void
+clipboard_copy_filepath_list (GList* file_list)
+{
+    GtkClipboard * clip = gtk_clipboard_get (GDK_SELECTION_CLIPBOARD);
+    GString *filepathlist = g_string_sized_new (8192);
+    for (GList *file = file_list; file != NULL; file = file->next)
+    {
+        gchar* file_name = NULL;
+        file_name = (char*) file->data;
+
+        g_string_append(filepathlist , file_name);
+        g_string_append(filepathlist , "\r\n");
+    }
+    gtk_clipboard_set_text (clip, filepathlist->str, filepathlist->len);
+}

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -132,4 +132,5 @@ clipboard_copy_filepath_list (GList* file_list)
         g_string_append(filepathlist , "\r\n");
     }
     gtk_clipboard_set_text (clip, filepathlist->str, filepathlist->len);
+    g_string_free(filepathlist, TRUE);
 }

--- a/src/clipboard.h
+++ b/src/clipboard.h
@@ -22,3 +22,6 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 void
 clipboard_copy_file_list (GList *file_list, guint32 copy);
+
+void
+clipboard_copy_filepath_list (GList *file_list);

--- a/src/fsearch_window.c
+++ b/src/fsearch_window.c
@@ -419,7 +419,17 @@ on_listview_key_press_event (GtkWidget *widget,
     FsearchApplicationWindow *win = user_data;
     g_assert (FSEARCH_WINDOW_IS_WINDOW (win));
     GActionGroup *group = G_ACTION_GROUP (win);
-    if (event->state & GDK_CONTROL_MASK) {
+    GdkModifierType modifiers;
+    modifiers = gtk_accelerator_get_default_mod_mask ();
+    if ((event->state & modifiers) == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) {
+        switch (event->keyval) {
+            case GDK_KEY_C:
+                g_action_group_activate_action (group, "copy_filepath_clipboard", NULL);
+                return TRUE;
+            default:
+                return FALSE;
+        }
+    } else if ((event->state & modifiers) == GDK_CONTROL_MASK) {
         switch (event->keyval) {
             case GDK_KEY_Return:
             case GDK_KEY_KP_Enter:
@@ -432,7 +442,7 @@ on_listview_key_press_event (GtkWidget *widget,
                 return FALSE;
         }
     }
-    else if (event->state & GDK_SHIFT_MASK) {
+    else if ((event->state & modifiers) == GDK_SHIFT_MASK) {
         switch (event->keyval) {
             case GDK_KEY_Delete:
                 g_action_group_activate_action (group, "delete_selection", NULL);

--- a/src/fsearch_window_actions.c
+++ b/src/fsearch_window_actions.c
@@ -273,6 +273,21 @@ fsearch_window_action_copy (GSimpleAction *action,
 }
 
 static void
+fsearch_window_action_copy_filepath (GSimpleAction *action,
+                                     GVariant      *variant,
+                                     gpointer       user_data)
+{
+    FsearchApplicationWindow *self = user_data;
+    GtkTreeSelection *selection = fsearch_application_window_get_listview_selection (self);
+    if (selection) {
+        GList *file_list = NULL;
+        gtk_tree_selection_selected_foreach (selection, copy_file, &file_list);
+        file_list = g_list_reverse (file_list);
+        clipboard_copy_filepath_list (file_list);
+    }
+}
+
+static void
 open_cb (GtkTreeModel *model,
          GtkTreePath *path,
          GtkTreeIter *iter,
@@ -672,6 +687,7 @@ static GActionEntry FsearchWindowActions[] = {
     { "open_with_other", fsearch_window_action_open_with_other },
     { "open_folder", fsearch_window_action_open_folder },
     { "copy_clipboard", fsearch_window_action_copy },
+    { "copy_filepath_clipboard", fsearch_window_action_copy_filepath },
     { "cut_clipboard", fsearch_window_action_cut },
     { "move_to_trash", fsearch_window_action_move_to_trash },
     { "delete_selection", fsearch_window_action_delete },
@@ -720,6 +736,7 @@ fsearch_window_actions_update   (FsearchApplicationWindow *self)
     action_set_enabled (group, "deselect_all", num_rows_selected);
     action_set_enabled (group, "invert_selection", num_rows_selected);
     action_set_enabled (group, "copy_clipboard", num_rows_selected);
+    action_set_enabled (group, "copy_filepath_clipboard", num_rows_selected);
     action_set_enabled (group, "cut_clipboard", num_rows_selected);
     action_set_enabled (group, "delete_selection", num_rows_selected);
     action_set_enabled (group, "move_to_trash", num_rows_selected);

--- a/src/menus.ui
+++ b/src/menus.ui
@@ -43,6 +43,11 @@
                 <attribute name="accel">&lt;control&gt;c</attribute>
                 <attribute name="icon">edit-copy</attribute>
             </item>
+            <item>
+                <attribute name="label" translatable="yes">_Copy Filepath</attribute>
+                <attribute name="action">win.copy_filepath_clipboard</attribute>
+                <attribute name="accel">&lt;shift&gt;&lt;control&gt;c</attribute>
+            </item>
         </section>
         <section id="fsearch_listview_menu_delete_section">
             <item>


### PR DESCRIPTION
shortcut for it is ctrl-shift-c

Changed test for modifer keys to work correctly.
More info about the issue here:
https://developer.gnome.org/gtk3/stable/checklist-modifiers.html

Should fix issue #74 