### PR TITLE
Implemented close application after opening a file / folder

### DIFF
--- a/src/fsearch_config.c
+++ b/src/fsearch_config.c
@@ -172,6 +172,10 @@ config_load (FsearchConfig *config)
                                                          "Interface",
                                                          "show_base_2_units",
                                                          false);
+        config->close_after_file_open = config_load_boolean (key_file,
+                                                             "Interface",
+                                                             "close_after_file_open",
+                                                             false);
 
         // Window
         config->restore_window_size = config_load_boolean (key_file,
@@ -370,6 +374,7 @@ config_load_default (FsearchConfig *config)
     config->show_filter = true;
     config->show_search_button = true;
     config->show_base_2_units = false;
+    config->close_after_file_open = false;
 
     // Columns
     config->show_listview_icons = true;
@@ -425,6 +430,7 @@ config_save (FsearchConfig *config)
     g_key_file_set_boolean (key_file, "Interface", "show_filter", config->show_filter);
     g_key_file_set_boolean (key_file, "Interface", "show_search_button", config->show_search_button);
     g_key_file_set_boolean (key_file, "Interface", "show_base_2_units", config->show_base_2_units);
+    g_key_file_set_boolean (key_file, "Interface", "close_after_file_open", config->close_after_file_open);
 
     // Window
     g_key_file_set_boolean (key_file, "Interface", "restore_window_size", config->restore_window_size);

--- a/src/fsearch_config.c
+++ b/src/fsearch_config.c
@@ -185,6 +185,12 @@ config_load (FsearchConfig *config)
                                                                     "action_after_file_open_mouse",
                                                                     false);
 
+        // Warning Dialogs
+        config->show_dialog_failed_opening = config_load_boolean(key_file,
+                                                                 "Dialogs",
+                                                                 "show_dialog_failed_opening",
+                                                                 true);
+
         // Window
         config->restore_window_size = config_load_boolean (key_file,
                                                          "Interface",
@@ -405,6 +411,9 @@ config_load_default (FsearchConfig *config)
     config->size_column_width = 75;
     config->modified_column_width = 125;
 
+    // Warning Dialogs
+    config->show_dialog_failed_opening = true;
+
     // Window
     config->restore_window_size = false;
     config->window_width = 800;
@@ -443,6 +452,9 @@ config_save (FsearchConfig *config)
     g_key_file_set_integer (key_file, "Interface", "action_after_file_open", config->action_after_file_open);
     g_key_file_set_boolean (key_file, "Interface", "action_after_file_open_keyboard", config->action_after_file_open_keyboard);
     g_key_file_set_boolean (key_file, "Interface", "action_after_file_open_mouse", config->action_after_file_open_mouse);
+
+    // Warning Dialogs
+    g_key_file_set_boolean (key_file, "Dialogs", "show_dialog_failed_opening", config->show_dialog_failed_opening);
 
     // Window
     g_key_file_set_boolean (key_file, "Interface", "restore_window_size", config->restore_window_size);

--- a/src/fsearch_config.c
+++ b/src/fsearch_config.c
@@ -172,10 +172,18 @@ config_load (FsearchConfig *config)
                                                          "Interface",
                                                          "show_base_2_units",
                                                          false);
-        config->close_after_file_open = config_load_boolean (key_file,
+        config->action_after_file_open = config_load_integer(key_file,
                                                              "Interface",
-                                                             "close_after_file_open",
-                                                             false);
+                                                             "action_after_file_open",
+                                                             0);
+        config->action_after_file_open_keyboard = config_load_boolean (key_file,
+                                                                    "Interface",
+                                                                    "action_after_file_open_keyboard",
+                                                                    false);
+        config->action_after_file_open_mouse = config_load_boolean (key_file,
+                                                                    "Interface",
+                                                                    "action_after_file_open_mouse",
+                                                                    false);
 
         // Window
         config->restore_window_size = config_load_boolean (key_file,
@@ -374,7 +382,9 @@ config_load_default (FsearchConfig *config)
     config->show_filter = true;
     config->show_search_button = true;
     config->show_base_2_units = false;
-    config->close_after_file_open = false;
+    config->action_after_file_open = 0;
+    config->action_after_file_open_keyboard = false;
+    config->action_after_file_open_mouse = false;
 
     // Columns
     config->show_listview_icons = true;
@@ -430,7 +440,9 @@ config_save (FsearchConfig *config)
     g_key_file_set_boolean (key_file, "Interface", "show_filter", config->show_filter);
     g_key_file_set_boolean (key_file, "Interface", "show_search_button", config->show_search_button);
     g_key_file_set_boolean (key_file, "Interface", "show_base_2_units", config->show_base_2_units);
-    g_key_file_set_boolean (key_file, "Interface", "close_after_file_open", config->close_after_file_open);
+    g_key_file_set_integer (key_file, "Interface", "action_after_file_open", config->action_after_file_open);
+    g_key_file_set_boolean (key_file, "Interface", "action_after_file_open_keyboard", config->action_after_file_open_keyboard);
+    g_key_file_set_boolean (key_file, "Interface", "action_after_file_open_mouse", config->action_after_file_open_mouse);
 
     // Window
     g_key_file_set_boolean (key_file, "Interface", "restore_window_size", config->restore_window_size);

--- a/src/fsearch_config.c
+++ b/src/fsearch_config.c
@@ -191,6 +191,12 @@ config_load (FsearchConfig *config)
                                                                  "show_dialog_failed_opening",
                                                                  true);
 
+        // Default actions
+        config->action_failed_opening_stay_open = config_load_boolean(key_file,
+                                                                     "Default_Actions",
+                                                                     "action_failed_opening_stay_open",
+                                                                     true);
+
         // Window
         config->restore_window_size = config_load_boolean (key_file,
                                                          "Interface",
@@ -414,6 +420,9 @@ config_load_default (FsearchConfig *config)
     // Warning Dialogs
     config->show_dialog_failed_opening = true;
 
+    // Default Actions
+    config->action_failed_opening_stay_open = true;
+
     // Window
     config->restore_window_size = false;
     config->window_width = 800;
@@ -455,6 +464,9 @@ config_save (FsearchConfig *config)
 
     // Warning Dialogs
     g_key_file_set_boolean (key_file, "Dialogs", "show_dialog_failed_opening", config->show_dialog_failed_opening);
+
+    // Default Actions
+    g_key_file_set_boolean (key_file, "Default_Actions", "action_failed_opening_stay_open", config->action_failed_opening_stay_open);
 
     // Window
     g_key_file_set_boolean (key_file, "Interface", "restore_window_size", config->restore_window_size);

--- a/src/fsearch_config.c
+++ b/src/fsearch_config.c
@@ -191,12 +191,6 @@ config_load (FsearchConfig *config)
                                                                  "show_dialog_failed_opening",
                                                                  true);
 
-        // Default actions
-        config->action_failed_opening_stay_open = config_load_boolean(key_file,
-                                                                     "Default_Actions",
-                                                                     "action_failed_opening_stay_open",
-                                                                     true);
-
         // Window
         config->restore_window_size = config_load_boolean (key_file,
                                                          "Interface",
@@ -420,9 +414,6 @@ config_load_default (FsearchConfig *config)
     // Warning Dialogs
     config->show_dialog_failed_opening = true;
 
-    // Default Actions
-    config->action_failed_opening_stay_open = true;
-
     // Window
     config->restore_window_size = false;
     config->window_width = 800;
@@ -464,9 +455,6 @@ config_save (FsearchConfig *config)
 
     // Warning Dialogs
     g_key_file_set_boolean (key_file, "Dialogs", "show_dialog_failed_opening", config->show_dialog_failed_opening);
-
-    // Default Actions
-    g_key_file_set_boolean (key_file, "Default_Actions", "action_failed_opening_stay_open", config->action_failed_opening_stay_open);
 
     // Window
     g_key_file_set_boolean (key_file, "Interface", "restore_window_size", config->restore_window_size);

--- a/src/fsearch_config.h
+++ b/src/fsearch_config.h
@@ -52,6 +52,9 @@ struct _FsearchConfig
     // Warning Dialogs
     bool show_dialog_failed_opening;
 
+    // Default actions
+    bool action_failed_opening_stay_open;
+
     // View menu
     bool show_menubar;
     bool show_statusbar;

--- a/src/fsearch_config.h
+++ b/src/fsearch_config.h
@@ -45,6 +45,7 @@ struct _FsearchConfig
     bool enable_dark_theme;
     bool enable_list_tooltips;
     bool restore_column_config;
+    bool close_after_file_open;
 
     // View menu
     bool show_menubar;

--- a/src/fsearch_config.h
+++ b/src/fsearch_config.h
@@ -49,6 +49,9 @@ struct _FsearchConfig
     bool action_after_file_open_keyboard;
     bool action_after_file_open_mouse;
 
+    // Warning Dialogs
+    bool show_dialog_failed_opening;
+
     // View menu
     bool show_menubar;
     bool show_statusbar;

--- a/src/fsearch_config.h
+++ b/src/fsearch_config.h
@@ -45,7 +45,9 @@ struct _FsearchConfig
     bool enable_dark_theme;
     bool enable_list_tooltips;
     bool restore_column_config;
-    bool close_after_file_open;
+    int action_after_file_open;
+    bool action_after_file_open_keyboard;
+    bool action_after_file_open_mouse;
 
     // View menu
     bool show_menubar;

--- a/src/fsearch_config.h
+++ b/src/fsearch_config.h
@@ -45,15 +45,12 @@ struct _FsearchConfig
     bool enable_dark_theme;
     bool enable_list_tooltips;
     bool restore_column_config;
-    int action_after_file_open;
+    uint32_t action_after_file_open;
     bool action_after_file_open_keyboard;
     bool action_after_file_open_mouse;
 
     // Warning Dialogs
     bool show_dialog_failed_opening;
-
-    // Default actions
-    bool action_failed_opening_stay_open;
 
     // View menu
     bool show_menubar;

--- a/src/fsearch_window.c
+++ b/src/fsearch_window.c
@@ -34,6 +34,7 @@
 #include "debug.h"
 #include "fsearch_limits.h"
 #include "gtk_support.h"
+#include "ui_utils.h"
 
 struct _FsearchApplicationWindow {
     GtkApplicationWindow parent_instance;
@@ -639,10 +640,6 @@ on_listview_row_activated (GtkTreeView       *tree_view,
                                                              _("Failed to open file"),
                                                              _("Do you want to keep the window open?"));
                     if (response != GTK_RESPONSE_YES) {
-                        fsearch_window_action_after_file_open(false);
-                    }
-                } else {
-                    if (!config->action_failed_opening_stay_open) {
                         fsearch_window_action_after_file_open(false);
                     }
                 }

--- a/src/fsearch_window.c
+++ b/src/fsearch_window.c
@@ -628,10 +628,12 @@ on_listview_row_activated (GtkTreeView       *tree_view,
             BTreeNode * node = db_search_entry_get_node (entry);
             if (launch_node (node)) {
                 // open succeeded
+                fsearch_window_action_after_file_open(true);
+            } else {
+                
             }
         }
     }
-    fsearch_window_action_after_file_open(true);
 }
 
 static void

--- a/src/fsearch_window.c
+++ b/src/fsearch_window.c
@@ -619,7 +619,7 @@ on_listview_row_activated (GtkTreeView       *tree_view,
                            GtkTreeViewColumn *column,
                            gpointer           user_data)
 {
-
+    FsearchApplicationWindow *self = user_data;
     GtkTreeModel *model = gtk_tree_view_get_model(tree_view);
     GtkTreeIter   iter;
     if (gtk_tree_model_get_iter(model, &iter, path)) {
@@ -630,7 +630,18 @@ on_listview_row_activated (GtkTreeView       *tree_view,
                 // open succeeded
                 fsearch_window_action_after_file_open(true);
             } else {
-                
+                // open failed
+                FsearchConfig *config = fsearch_application_get_config (FSEARCH_APPLICATION_DEFAULT);
+                if (config->show_dialog_failed_opening) {
+                    gint response = ui_utils_run_gtk_dialog (GTK_WIDGET (self),
+                                                             GTK_MESSAGE_WARNING,
+                                                             GTK_BUTTONS_YES_NO,
+                                                             _("Failed to open file"),
+                                                             _("Do you want to keep the window open?"));
+                    if (response != GTK_RESPONSE_YES) {
+                        fsearch_window_action_after_file_open(false);
+                    }
+                }
             }
         }
     }

--- a/src/fsearch_window.c
+++ b/src/fsearch_window.c
@@ -633,7 +633,8 @@ on_listview_row_activated (GtkTreeView       *tree_view,
             } else {
                 // open failed
                 FsearchConfig *config = fsearch_application_get_config (FSEARCH_APPLICATION_DEFAULT);
-                if (config->show_dialog_failed_opening) {
+                if ((config->action_after_file_open_keyboard || config->action_after_file_open_mouse) 
+                && config->show_dialog_failed_opening) {
                     gint response = ui_utils_run_gtk_dialog (GTK_WIDGET (self),
                                                              GTK_MESSAGE_WARNING,
                                                              GTK_BUTTONS_YES_NO,

--- a/src/fsearch_window.c
+++ b/src/fsearch_window.c
@@ -641,6 +641,10 @@ on_listview_row_activated (GtkTreeView       *tree_view,
                     if (response != GTK_RESPONSE_YES) {
                         fsearch_window_action_after_file_open(false);
                     }
+                } else {
+                    if (!config->action_failed_opening_stay_open) {
+                        fsearch_window_action_after_file_open(false);
+                    }
                 }
             }
         }

--- a/src/fsearch_window.c
+++ b/src/fsearch_window.c
@@ -629,6 +629,7 @@ on_listview_row_activated (GtkTreeView       *tree_view,
             launch_node (node);
         }
     }
+    fsearch_window_action_after_file_open(true);
 }
 
 static void

--- a/src/fsearch_window_actions.c
+++ b/src/fsearch_window_actions.c
@@ -415,10 +415,6 @@ fsearch_window_action_open (GSimpleAction *action,
                     if (response != GTK_RESPONSE_YES) {
                         fsearch_window_action_after_file_open(false);
                     }
-                } else {
-                    if (!config->action_failed_opening_stay_open) {
-                        fsearch_window_action_after_file_open(false);
-                    }
                 }
             }
         }
@@ -468,10 +464,6 @@ fsearch_window_action_open_folder (GSimpleAction *action,
                                                              _("Failed to open file"),
                                                              _("Do you want to keep the window open?"));
                     if (response != GTK_RESPONSE_YES) {
-                        fsearch_window_action_after_file_open(false);
-                    }
-                } else {
-                    if (!config->action_failed_opening_stay_open) {
                         fsearch_window_action_after_file_open(false);
                     }
                 }

--- a/src/fsearch_window_actions.c
+++ b/src/fsearch_window_actions.c
@@ -419,6 +419,11 @@ fsearch_window_action_open_folder (GSimpleAction *action,
             gtk_tree_selection_selected_foreach (selection, open_folder_cb, NULL);
         }
     }
+
+    FsearchConfig *config = fsearch_application_get_config (FSEARCH_APPLICATION_DEFAULT);
+    if (config->close_after_file_open) {
+        g_application_quit (G_APPLICATION (FSEARCH_APPLICATION_DEFAULT));
+    }
 }
 
 static void

--- a/src/fsearch_window_actions.c
+++ b/src/fsearch_window_actions.c
@@ -405,7 +405,17 @@ fsearch_window_action_open (GSimpleAction *action,
                 fsearch_window_action_after_file_open(false);
             } else {
                 // open failed
-
+                FsearchConfig *config = fsearch_application_get_config (FSEARCH_APPLICATION_DEFAULT);
+                if (config->show_dialog_failed_opening) {
+                    gint response = ui_utils_run_gtk_dialog (GTK_WIDGET (self),
+                                                             GTK_MESSAGE_WARNING,
+                                                             GTK_BUTTONS_YES_NO,
+                                                             _("Failed to open file"),
+                                                             _("Do you want to keep the window open?"));
+                    if (response != GTK_RESPONSE_YES) {
+                        fsearch_window_action_after_file_open(false);
+                    }
+                }
             }
         }
     }
@@ -445,7 +455,18 @@ fsearch_window_action_open_folder (GSimpleAction *action,
                 // open succeeded
                 fsearch_window_action_after_file_open(false);
             } else {
-
+                // open failed
+                FsearchConfig *config = fsearch_application_get_config (FSEARCH_APPLICATION_DEFAULT);
+                if (config->show_dialog_failed_opening) {
+                    gint response = ui_utils_run_gtk_dialog (GTK_WIDGET (self),
+                                                             GTK_MESSAGE_WARNING,
+                                                             GTK_BUTTONS_YES_NO,
+                                                             _("Failed to open file"),
+                                                             _("Do you want to keep the window open?"));
+                    if (response != GTK_RESPONSE_YES) {
+                        fsearch_window_action_after_file_open(false);
+                    }
+                }
             }
         }
     }

--- a/src/fsearch_window_actions.c
+++ b/src/fsearch_window_actions.c
@@ -321,6 +321,20 @@ open_with_cb (GtkTreeModel *model,
     }
 }
 
+void
+fsearch_window_action_after_file_open(bool action_mouse) {
+    FsearchConfig *config = fsearch_application_get_config (FSEARCH_APPLICATION_DEFAULT);
+
+    if ((config->action_after_file_open_keyboard && !action_mouse)
+    || (config->action_after_file_open_mouse && action_mouse)) {
+        if (config->action_after_file_open == 1) {
+            g_application_quit (G_APPLICATION (FSEARCH_APPLICATION_DEFAULT));
+        } else {
+            gtk_window_iconify (gtk_application_get_active_window (G_APPLICATION (FSEARCH_APPLICATION_DEFAULT)));
+        }
+    }
+}
+
 static void
 fsearch_window_action_open_with (GSimpleAction *action,
                                  GVariant      *variant,
@@ -384,11 +398,7 @@ fsearch_window_action_open (GSimpleAction *action,
             gtk_tree_selection_selected_foreach (selection, open_cb, NULL);
         }
     }
-
-    FsearchConfig *config = fsearch_application_get_config (FSEARCH_APPLICATION_DEFAULT);
-    if (config->close_after_file_open) {
-        g_application_quit (G_APPLICATION (FSEARCH_APPLICATION_DEFAULT));
-    }
+    fsearch_window_action_after_file_open(false);
 }
 
 static void
@@ -419,11 +429,7 @@ fsearch_window_action_open_folder (GSimpleAction *action,
             gtk_tree_selection_selected_foreach (selection, open_folder_cb, NULL);
         }
     }
-
-    FsearchConfig *config = fsearch_application_get_config (FSEARCH_APPLICATION_DEFAULT);
-    if (config->close_after_file_open) {
-        g_application_quit (G_APPLICATION (FSEARCH_APPLICATION_DEFAULT));
-    }
+    fsearch_window_action_after_file_open(false);
 }
 
 static void

--- a/src/fsearch_window_actions.c
+++ b/src/fsearch_window_actions.c
@@ -384,6 +384,11 @@ fsearch_window_action_open (GSimpleAction *action,
             gtk_tree_selection_selected_foreach (selection, open_cb, NULL);
         }
     }
+
+    FsearchConfig *config = fsearch_application_get_config (FSEARCH_APPLICATION_DEFAULT);
+    if (config->close_after_file_open) {
+        g_application_quit (G_APPLICATION (FSEARCH_APPLICATION_DEFAULT));
+    }
 }
 
 static void

--- a/src/fsearch_window_actions.c
+++ b/src/fsearch_window_actions.c
@@ -415,6 +415,10 @@ fsearch_window_action_open (GSimpleAction *action,
                     if (response != GTK_RESPONSE_YES) {
                         fsearch_window_action_after_file_open(false);
                     }
+                } else {
+                    if (!config->action_failed_opening_stay_open) {
+                        fsearch_window_action_after_file_open(false);
+                    }
                 }
             }
         }
@@ -464,6 +468,10 @@ fsearch_window_action_open_folder (GSimpleAction *action,
                                                              _("Failed to open file"),
                                                              _("Do you want to keep the window open?"));
                     if (response != GTK_RESPONSE_YES) {
+                        fsearch_window_action_after_file_open(false);
+                    }
+                } else {
+                    if (!config->action_failed_opening_stay_open) {
                         fsearch_window_action_after_file_open(false);
                     }
                 }

--- a/src/fsearch_window_actions.c
+++ b/src/fsearch_window_actions.c
@@ -333,7 +333,7 @@ fsearch_window_action_after_file_open(bool action_mouse) {
         if (config->action_after_file_open == 1) {
             g_application_quit (G_APPLICATION (FSEARCH_APPLICATION_DEFAULT));
         } else {
-            gtk_window_iconify (gtk_application_get_active_window (G_APPLICATION (FSEARCH_APPLICATION_DEFAULT)));
+            gtk_window_iconify (gtk_application_get_active_window (GTK_APPLICATION (FSEARCH_APPLICATION_DEFAULT)));
         }
     }
 }
@@ -402,10 +402,13 @@ fsearch_window_action_open (GSimpleAction *action,
             gtk_tree_selection_selected_foreach (selection, open_cb, &open_failed);
             if (!open_failed) {
                 // open succeeded
+                fsearch_window_action_after_file_open(false);
+            } else {
+                // open failed
+
             }
         }
     }
-    fsearch_window_action_after_file_open(false);
 }
 
 static void
@@ -440,10 +443,12 @@ fsearch_window_action_open_folder (GSimpleAction *action,
             gtk_tree_selection_selected_foreach (selection, open_folder_cb, &open_failed);
             if (!open_failed) {
                 // open succeeded
+                fsearch_window_action_after_file_open(false);
+            } else {
+
             }
         }
     }
-    fsearch_window_action_after_file_open(false);
 }
 
 static void

--- a/src/fsearch_window_actions.h
+++ b/src/fsearch_window_actions.h
@@ -25,3 +25,6 @@ fsearch_window_actions_init   (FsearchApplicationWindow *self);
 
 void
 fsearch_window_actions_update   (FsearchApplicationWindow *self);
+
+void
+fsearch_window_action_after_file_open(bool action_mouse);

--- a/src/preferences.ui
+++ b/src/preferences.ui
@@ -672,6 +672,54 @@ since not every GTK+ theme provides a dark version.</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkGrid">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">6</property>
+                <property name="margin_right">6</property>
+                <property name="margin_top">6</property>
+                <property name="margin_bottom">6</property>
+                <property name="row_spacing">6</property>
+                <property name="column_spacing">6</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="expand">False</property>
+                    <property name="label" translatable="yes">Show warning dialogs when:</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="show_dialog_failed_opening">
+                    <property name="label" translatable="yes">file / folder failed to open</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Dialogs</property>
+              </object>
+              <packing>
+                <property name="tab_fill">False</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">True</property>

--- a/src/preferences.ui
+++ b/src/preferences.ui
@@ -143,7 +143,7 @@
                     <property name="halign">start</property>
                     <property name="margin-left">6</property>
                     <property name="expand">False</property>
-                    <property name="label" translatable="yes">Behaviour after opening a file</property>
+                    <property name="label" translatable="yes">Behaviour after successfully opening a file</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>

--- a/src/preferences.ui
+++ b/src/preferences.ui
@@ -138,6 +138,20 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkCheckButton" id="close_after_file_open">
+                    <property name="label" translatable="yes">Close the search window after opening a file</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">6</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkInfoBar" id="enable_dark_theme_infobar">
                     <property name="can_focus">False</property>
                     <property name="show_close_button">True</property>

--- a/src/preferences.ui
+++ b/src/preferences.ui
@@ -134,20 +134,66 @@
                   <packing>
                     <property name="left_attach">0</property>
                     <property name="top_attach">1</property>
-                    <property name="width">2</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkCheckButton" id="close_after_file_open">
-                    <property name="label" translatable="yes">Close the search window after opening a file</property>
+                  <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="margin-left">6</property>
+                    <property name="expand">False</property>
+                    <property name="label" translatable="yes">Behaviour after opening a file</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
                     <property name="top_attach">6</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBoxText" id="action_after_file_open">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="active">0</property>
+                    <property name="halign">end</property>
+                    <property name="hexpand">true</property>
+                    <items>
+                      <item id="FSEARCH_AFTER_FILE_OPEN_MINIMIZE" translatable="yes">Minimize</item>
+                      <item id="FSEARCH_AFTER_FILE_OPEN_CLOSE" translatable="yes">Close</item>
+                    </items>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">6</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="action_after_file_open_keyboard">
+                    <property name="label" translatable="yes">with keyboard shortcuts or menu entries</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="margin-left">24</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">7</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="action_after_file_open_mouse">
+                    <property name="label" translatable="yes">with double click</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="margin-left">24</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">8</property>
                     <property name="width">2</property>
                   </packing>
                 </child>

--- a/src/preferences_ui.c
+++ b/src/preferences_ui.c
@@ -257,6 +257,11 @@ preferences_ui_launch (FsearchConfig *config, GtkWindow *window)
     gtk_toggle_button_set_active(show_base_2_units,
                                  main_config->show_base_2_units);
 
+    GtkToggleButton *close_after_file_open = GTK_TOGGLE_BUTTON (builder_get_object (builder,
+                                                                                    "close_after_file_open"));
+    gtk_toggle_button_set_active(close_after_file_open,
+                                 main_config->close_after_file_open);
+
     // Search page
     GtkToggleButton *auto_search_in_path_button = GTK_TOGGLE_BUTTON (builder_get_object (builder,
                                                                                          "auto_search_in_path_button"));
@@ -403,6 +408,7 @@ preferences_ui_launch (FsearchConfig *config, GtkWindow *window)
         main_config->restore_window_size = gtk_toggle_button_get_active (restore_win_size_button);
         main_config->update_database_on_launch = gtk_toggle_button_get_active (update_db_at_start_button);
         main_config->show_base_2_units = gtk_toggle_button_get_active (show_base_2_units);
+        main_config->close_after_file_open = gtk_toggle_button_get_active (close_after_file_open);
 
         bool old_exclude_hidden_items = main_config->exclude_hidden_items;
         main_config->exclude_hidden_items = gtk_toggle_button_get_active (exclude_hidden_items_button);

--- a/src/preferences_ui.c
+++ b/src/preferences_ui.c
@@ -257,10 +257,20 @@ preferences_ui_launch (FsearchConfig *config, GtkWindow *window)
     gtk_toggle_button_set_active(show_base_2_units,
                                  main_config->show_base_2_units);
 
-    GtkToggleButton *close_after_file_open = GTK_TOGGLE_BUTTON (builder_get_object (builder,
-                                                                                    "close_after_file_open"));
-    gtk_toggle_button_set_active(close_after_file_open,
-                                 main_config->close_after_file_open);
+    GtkComboBoxText *action_after_file_open = GTK_COMBO_BOX_TEXT( builder_get_object(builder,
+                                                                                     "action_after_file_open"));
+    gtk_combo_box_set_active(action_after_file_open,
+                             main_config->action_after_file_open);
+
+    GtkToggleButton *action_after_file_open_keyboard = GTK_TOGGLE_BUTTON (builder_get_object (builder,
+                                                                                              "action_after_file_open_keyboard"));
+    gtk_toggle_button_set_active(action_after_file_open_keyboard,
+                                 main_config->action_after_file_open_keyboard);
+
+    GtkToggleButton *action_after_file_open_mouse = GTK_TOGGLE_BUTTON (builder_get_object (builder,
+                                                                                           "action_after_file_open_mouse"));
+    gtk_toggle_button_set_active(action_after_file_open_mouse,
+                                 main_config->action_after_file_open_mouse);
 
     // Search page
     GtkToggleButton *auto_search_in_path_button = GTK_TOGGLE_BUTTON (builder_get_object (builder,
@@ -408,7 +418,9 @@ preferences_ui_launch (FsearchConfig *config, GtkWindow *window)
         main_config->restore_window_size = gtk_toggle_button_get_active (restore_win_size_button);
         main_config->update_database_on_launch = gtk_toggle_button_get_active (update_db_at_start_button);
         main_config->show_base_2_units = gtk_toggle_button_get_active (show_base_2_units);
-        main_config->close_after_file_open = gtk_toggle_button_get_active (close_after_file_open);
+        main_config->action_after_file_open = gtk_combo_box_get_active(action_after_file_open);
+        main_config->action_after_file_open_keyboard = gtk_toggle_button_get_active (action_after_file_open_keyboard);
+        main_config->action_after_file_open_mouse = gtk_toggle_button_get_active (action_after_file_open_mouse);
 
         bool old_exclude_hidden_items = main_config->exclude_hidden_items;
         main_config->exclude_hidden_items = gtk_toggle_button_get_active (exclude_hidden_items_button);

--- a/src/preferences_ui.c
+++ b/src/preferences_ui.c
@@ -209,25 +209,6 @@ update_location_config (GtkTreeModel *model, GList *list)
     return list;
 }
 
-static void
-show_dialog_failed_opening_toggled(GtkToggleButton *togglebutton, gpointer user_data)
-{
-    if (!gtk_toggle_button_get_active(togglebutton)) {
-        GtkWidget *window = gtk_widget_get_toplevel (GTK_WIDGET (togglebutton));
-        gint response = ui_utils_run_gtk_dialog (GTK_WINDOW (window),
-                                                 GTK_MESSAGE_QUESTION,
-                                                 GTK_BUTTONS_YES_NO,
-                                                 _("Default action if file / folder failed to open"),
-                                                 _("Do you want to keep the window open instead of closing it?"));
-        FsearchConfig *config = fsearch_application_get_config (FSEARCH_APPLICATION_DEFAULT);
-        if (response == GTK_RESPONSE_YES) {            
-            config->action_failed_opening_stay_open = true;
-        } else {
-            config->action_failed_opening_stay_open = false;
-        }
-    }
-}
-
 void
 preferences_ui_launch (FsearchConfig *config, GtkWindow *window)
 {
@@ -340,10 +321,6 @@ preferences_ui_launch (FsearchConfig *config, GtkWindow *window)
                                                                                          "show_dialog_failed_opening"));
     gtk_toggle_button_set_active(show_dialog_failed_opening,
                                  main_config->show_dialog_failed_opening);
-    g_signal_connect(show_dialog_failed_opening,
-                     "toggled",
-                     G_CALLBACK (show_dialog_failed_opening_toggled),
-                     show_dialog_failed_opening);
 
     // Include page
     GtkTreeModel *include_model = create_tree_model (main_config->locations);

--- a/src/preferences_ui.c
+++ b/src/preferences_ui.c
@@ -207,6 +207,14 @@ update_location_config (GtkTreeModel *model, GList *list)
     return list;
 }
 
+static void
+show_dialog_failed_opening_toggled(GtkToggleButton *togglebutton, gpointer user_data)
+{
+    if (!gtk_toggle_button_get_active(togglebutton)) {
+        
+    }
+}
+
 void
 preferences_ui_launch (FsearchConfig *config, GtkWindow *window)
 {
@@ -313,6 +321,16 @@ preferences_ui_launch (FsearchConfig *config, GtkWindow *window)
                                                                                         "update_db_at_start_button"));
     gtk_toggle_button_set_active (update_db_at_start_button,
                                   main_config->update_database_on_launch);
+
+    // Dialog page
+    GtkToggleButton *show_dialog_failed_opening = GTK_TOGGLE_BUTTON (builder_get_object (builder,
+                                                                                         "show_dialog_failed_opening"));
+    gtk_toggle_button_set_active(show_dialog_failed_opening,
+                                 main_config->show_dialog_failed_opening);
+    g_signal_connect(show_dialog_failed_opening,
+                     "toggled",
+                     G_CALLBACK (show_dialog_failed_opening_toggled),
+                     show_dialog_failed_opening);
 
     // Include page
     GtkTreeModel *include_model = create_tree_model (main_config->locations);
@@ -425,6 +443,8 @@ preferences_ui_launch (FsearchConfig *config, GtkWindow *window)
         main_config->action_after_file_open = gtk_combo_box_get_active(action_after_file_open);
         main_config->action_after_file_open_keyboard = gtk_toggle_button_get_active (action_after_file_open_keyboard);
         main_config->action_after_file_open_mouse = gtk_toggle_button_get_active (action_after_file_open_mouse);
+        // Dialogs
+        main_config->show_dialog_failed_opening = gtk_toggle_button_get_active (show_dialog_failed_opening);
 
         bool old_exclude_hidden_items = main_config->exclude_hidden_items;
         main_config->exclude_hidden_items = gtk_toggle_button_get_active (exclude_hidden_items_button);

--- a/src/preferences_ui.c
+++ b/src/preferences_ui.c
@@ -18,9 +18,11 @@
 
 #include <gtk/gtk.h>
 #include <glib.h>
+#include <glib/gi18n.h>
 #include <stdlib.h>
 #include <string.h>
 #include "fsearch.h"
+#include "ui_utils.h"
 
 enum
 {
@@ -211,7 +213,18 @@ static void
 show_dialog_failed_opening_toggled(GtkToggleButton *togglebutton, gpointer user_data)
 {
     if (!gtk_toggle_button_get_active(togglebutton)) {
-        
+        GtkWidget *window = gtk_widget_get_toplevel (GTK_WIDGET (togglebutton));
+        gint response = ui_utils_run_gtk_dialog (GTK_WINDOW (window),
+                                                 GTK_MESSAGE_QUESTION,
+                                                 GTK_BUTTONS_YES_NO,
+                                                 _("Default action if file / folder failed to open"),
+                                                 _("Do you want to keep the window open instead of closing it?"));
+        FsearchConfig *config = fsearch_application_get_config (FSEARCH_APPLICATION_DEFAULT);
+        if (response == GTK_RESPONSE_YES) {            
+            config->action_failed_opening_stay_open = true;
+        } else {
+            config->action_failed_opening_stay_open = false;
+        }
     }
 }
 


### PR DESCRIPTION
I tried my hands on implementing issue #84 

At the moment it closes the application after opening the file (or the folder of the file) via the keyboard.

But it doesn't work when you open it via the mouse (double-clicking on it).
Someone can argue if this should be the case or not.
Personally I would want it to stay open when using the mouse because then I'm looking for something in the file and maybe opening another file after that.

Another point would be if the application should close or minimize into the taskbar?