### PR TITLE
fix  Chinese Character Encoding error in mips64 linux.

### DIFF
--- a/src/list_model.c
+++ b/src/list_model.c
@@ -498,7 +498,7 @@ list_model_get_value(GtkTreeModel *tree_model, GtkTreeIter *iter, gint column, G
             else {
                 snprintf(output, sizeof(output), "%d Items", num_children);
             }
-            g_value_set_static_string(value, output);
+            g_value_take_string(value, strdup(output));
         }
         else {
             FsearchConfig *config = fsearch_application_get_config(FSEARCH_APPLICATION_DEFAULT);
@@ -523,7 +523,7 @@ list_model_get_value(GtkTreeModel *tree_model, GtkTreeIter *iter, gint column, G
                  sizeof(output),
                  "%Y-%m-%d %H:%M", //"%Y-%m-%d %H:%M",
                  localtime(&mtime));
-        g_value_set_static_string(value, output);
+        g_value_take_string(value, strdup(output));
         break;
     }
 }


### PR DESCRIPTION
in mips64 linux system, encounted Chinese Character Encoding error in  "Size" and "Date Modified" row.

g_value_set_static_string means static not stack. here is the source code of g_value_set_static_string.
void
g_value_set_static_string (GValue      *value,
			   const gchar *v_string)
{
  g_return_if_fail (G_VALUE_HOLDS_STRING (value));
  
  if (!(value->data[1].v_uint & G_VALUE_NOCOPY_CONTENTS))
    g_free (value->data[0].v_pointer);
  value->data[1].v_uint = G_VALUE_NOCOPY_CONTENTS;
  value->data[0].v_pointer = (gchar*) v_string;
}

tested on mips64 linux.