### PR TITLE
window: save column widths on shutdown (fixes #290)

### DIFF
--- a/src/fsearch_window.c
+++ b/src/fsearch_window.c
@@ -1221,6 +1221,23 @@ fsearch_application_window_prepare_shutdown(gpointer self) {
             g_clear_pointer(&config->sort_by, g_free);
         }
         config->sort_by = get_sort_name_for_type(fsearch_list_view_get_sort_order(win->result_view->list_view));
+
+        // update the config with the widths of all columns whose width we can store
+        const struct { int type; uint32_t *width; } columns[] = {
+            { DATABASE_INDEX_TYPE_NAME,              &config->name_column_width      },
+            { DATABASE_INDEX_TYPE_PATH,              &config->path_column_width      },
+            { DATABASE_INDEX_TYPE_FILETYPE,          &config->type_column_width      },
+            { DATABASE_INDEX_TYPE_EXTENSION,         &config->extension_column_width },
+            { DATABASE_INDEX_TYPE_SIZE,              &config->size_column_width      },
+            { DATABASE_INDEX_TYPE_MODIFICATION_TIME, &config->modified_column_width  },
+        };
+        for (int i = 0; i < G_N_ELEMENTS(columns); i++) {
+            const FsearchListViewColumn *col = fsearch_list_view_get_first_column_for_type(
+                    win->result_view->list_view, columns[i].type);
+            if (col) {
+                *columns[i].width = col->width;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
I couldn't find an `ARRAY_SIZE()` macro or anything similar. Please let me know if I've missed something. Also feel free to directly change anything that doesn't match your code style preference.