### PR TITLE
Add setting to exit the application when Escape is pressed

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,3 +10,4 @@ Version 0.2 Alpha
 * Add .odp and .ods files to document filter
 * "Open with" menu now only shows applications which can handle the selected files
 * Improve support for non-Linux systems
+* Add option to exit FSearch when Escape is pressed instead of minimizing the window

--- a/src/fsearch.c
+++ b/src/fsearch.c
@@ -90,6 +90,9 @@ database_update(FsearchApplication *app, bool rescan);
 static void
 action_set_enabled(const char *action_name, gboolean enabled);
 
+static void
+set_accels_for_escape(GApplication *app);
+
 static gboolean
 on_database_auto_update(gpointer user_data) {
     FsearchApplication *self = FSEARCH_APPLICATION(user_data);
@@ -421,6 +424,8 @@ on_preferences_ui_finished(FsearchConfig *new_config) {
             fsearch_application_window_update_listview_config(window);
         }
     }
+
+    set_accels_for_escape(G_APPLICATION(app));
 }
 
 static void
@@ -542,6 +547,25 @@ set_accel_for_action(GApplication *app, const char *action, const char *accel) {
 }
 
 static void
+set_accels_for_action(GApplication *app, const char *action, const gchar* const* accels) {
+    gtk_application_set_accels_for_action(GTK_APPLICATION(app), action, accels);
+}
+
+static void
+set_accels_for_escape(GApplication *app) {
+    FsearchApplication *fsearch = FSEARCH_APPLICATION(app);
+
+    if (fsearch->config->exit_on_escape) {
+        set_accels_for_action(app, "win.hide_window", (const gchar *const[]){NULL});
+        set_accels_for_action(app, "app.quit", (const gchar *const[]){"<control>q", "Escape", NULL});
+    }
+    else {
+        set_accel_for_action(app, "win.hide_window", "Escape");
+        set_accel_for_action(app, "app.quit", "<control>q");
+    }
+}
+
+static void
 fsearch_application_startup(GApplication *app) {
     g_assert(FSEARCH_IS_APPLICATION(app));
     G_APPLICATION_CLASS(fsearch_application_parent_class)->startup(app);
@@ -593,14 +617,13 @@ fsearch_application_startup(GApplication *app) {
     set_accel_for_action(app, "win.focus_search", "<control>f");
     set_accel_for_action(app, "app.new_window", "<control>n");
     set_accel_for_action(app, "win.select_all", "<control>a");
-    set_accel_for_action(app, "win.hide_window", "Escape");
     set_accel_for_action(app, "win.match_case", "<control>i");
     set_accel_for_action(app, "win.search_mode", "<control>r");
     set_accel_for_action(app, "win.search_in_path", "<control>u");
     set_accel_for_action(app, "app.update_database", "<control><shift>r");
     set_accel_for_action(app, "app.preferences(uint32 0)", "<control>p");
     set_accel_for_action(app, "win.close_window", "<control>w");
-    set_accel_for_action(app, "app.quit", "<control>q");
+    set_accels_for_escape(app);
 
     fsearch->db_pool = g_thread_pool_new(database_pool_func, app, 1, TRUE, NULL);
     fsearch->is_shutting_down = false;

--- a/src/fsearch_config.c
+++ b/src/fsearch_config.c
@@ -247,6 +247,7 @@ config_load(FsearchConfig *config) {
             config_load_boolean(key_file, "Interface", "action_after_file_open_keyboard", false);
         config->action_after_file_open_mouse =
             config_load_boolean(key_file, "Interface", "action_after_file_open_mouse", false);
+        config->exit_on_escape = config_load_boolean(key_file, "Interface", "exit_on_escape", false);
         config->show_indexing_status = config_load_boolean(key_file, "Interface", "show_indexing_status", true);
 
         // Warning Dialogs
@@ -376,6 +377,7 @@ config_load_default(FsearchConfig *config) {
     config->action_after_file_open = ACTION_AFTER_OPEN_NOTHING;
     config->action_after_file_open_keyboard = false;
     config->action_after_file_open_mouse = false;
+    config->exit_on_escape = false;
     config->show_indexing_status = true;
 
     // Columns
@@ -549,6 +551,7 @@ config_save(FsearchConfig *config) {
                            "action_after_file_open_keyboard",
                            config->action_after_file_open_keyboard);
     g_key_file_set_boolean(key_file, "Interface", "action_after_file_open_mouse", config->action_after_file_open_mouse);
+    g_key_file_set_boolean(key_file, "Interface", "exit_on_escape", config->exit_on_escape);
     g_key_file_set_boolean(key_file, "Interface", "show_indexing_status", config->show_indexing_status);
 
     // Warning Dialogs

--- a/src/fsearch_config.h
+++ b/src/fsearch_config.h
@@ -70,6 +70,7 @@ struct _FsearchConfig {
     FsearchConfigActionAfterOpen action_after_file_open;
     bool action_after_file_open_keyboard;
     bool action_after_file_open_mouse;
+    bool exit_on_escape;
     bool show_indexing_status;
 
     // Warning Dialogs

--- a/src/fsearch_preferences.ui
+++ b/src/fsearch_preferences.ui
@@ -189,6 +189,21 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="exit_on_escape_button">
+                                <property name="label" translatable="yes">Exit on Escape</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="has-tooltip">True</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">4</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFrame" id="action_after_file_open_frame">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -288,7 +303,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">4</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                           </object>
@@ -1938,6 +1953,23 @@ If you want to update the database in the background, even when FSearch is not r
                     <property name="name">page34</property>
                     <property name="title" translatable="yes">page34</property>
                     <property name="position">34</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="help_exit_on_escape">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">&lt;b&gt;Exit on Escape:&lt;/b&gt;
+
+If enabled, FSearch exits when the Escape key is pressed instead of the window being minimized.</property>
+                    <property name="use-markup">True</property>
+                    <property name="wrap">True</property>
+                    <property name="selectable">True</property>
+                  </object>
+                  <packing>
+                    <property name="name">page35</property>
+                    <property name="title" translatable="yes">page35</property>
+                    <property name="position">35</property>
                   </packing>
                 </child>
               </object>

--- a/src/fsearch_preferences_ui.c
+++ b/src/fsearch_preferences_ui.c
@@ -44,6 +44,7 @@ typedef struct {
     GtkToggleButton *show_menubar_button;
     GtkToggleButton *show_tooltips_button;
     GtkToggleButton *restore_win_size_button;
+    GtkToggleButton *exit_on_escape_button;
     GtkToggleButton *restore_sort_order_button;
     GtkToggleButton *restore_column_config_button;
     GtkToggleButton *double_click_path_button;
@@ -431,6 +432,7 @@ preferences_ui_get_state(FsearchPreferencesInterface *ui) {
     new_config->double_click_path = gtk_toggle_button_get_active(ui->double_click_path_button);
     new_config->enable_list_tooltips = gtk_toggle_button_get_active(ui->show_tooltips_button);
     new_config->restore_window_size = gtk_toggle_button_get_active(ui->restore_win_size_button);
+    new_config->exit_on_escape = gtk_toggle_button_get_active(ui->exit_on_escape_button);
     new_config->update_database_on_launch = gtk_toggle_button_get_active(ui->update_db_at_start_button);
     new_config->update_database_every = gtk_toggle_button_get_active(ui->auto_update_checkbox);
     new_config->update_database_every_hours = gtk_spin_button_get_value_as_int(
@@ -531,6 +533,9 @@ preferences_ui_init(FsearchPreferencesInterface *ui, FsearchPreferencesPage page
 
     ui->restore_win_size_button =
         toggle_button_get(ui->builder, "restore_win_size_button", "help_window_size", new_config->restore_window_size);
+
+    ui->exit_on_escape_button =
+        toggle_button_get(ui->builder, "exit_on_escape_button", "help_exit_on_escape", new_config->exit_on_escape);
 
     ui->restore_sort_order_button = toggle_button_get(ui->builder,
                                                       "restore_sort_order_button",


### PR DESCRIPTION
This adds a configuration option to allow switching between the current Escape key behavior (minimizing the window) and a new behavior (exiting the application). I find this very helpful because it somewhat mimicks the _Everything_ behavior which can minimize to the tray area when Escape is pressed, at least until #52 is implemented.

Consider this a suggestion for now. If you're interested in merging this I'll double-check that the translation works and I'll add one or two translations as well.

I've also toyed with the idea of making the option a combobox like "Behavior after successfully opening a file" since the same three options would apply to the Escape key press behavior, so that would be a slightly different approach.