### PR TITLE
fsearch_window.c get_sort_type_for_name: Add nullptr check

### DIFF
--- a/src/fsearch_window.c
+++ b/src/fsearch_window.c
@@ -1134,6 +1134,10 @@ fsearch_application_window_update_query_flags(FsearchApplicationWindow *win) {
 
 static FsearchDatabaseIndexType
 get_sort_type_for_name(const char *name) {
+    if (!name) {
+        g_warning("[get_sort_type_for_name] name is nullptr");
+        return 0;
+    }
     if (!strcmp(name, DATABASE_INDEX_TYPE_NAME_STRING)) {
         return DATABASE_INDEX_TYPE_NAME;
     }

--- a/src/fsearch_window.c
+++ b/src/fsearch_window.c
@@ -1136,7 +1136,7 @@ static FsearchDatabaseIndexType
 get_sort_type_for_name(const char *name) {
     if (!name) {
         g_warning("[get_sort_type_for_name] name is nullptr");
-        return 0;
+        return DATABASE_INDEX_TYPE_NAME;
     }
     if (!strcmp(name, DATABASE_INDEX_TYPE_NAME_STRING)) {
         return DATABASE_INDEX_TYPE_NAME;


### PR DESCRIPTION
When running this on my Debian 11 installation, the param `name` in `get_sort_type_for_name` would be null on startup. I assume returning 0 might cause issues, but the program worked flawlessly after adding this check.