### PR TITLE
Added file preview feature

### DIFF
--- a/src/fsearch.c
+++ b/src/fsearch.c
@@ -33,6 +33,7 @@
 #include "fsearch_window.h"
 #include "icon_resources.h"
 #include "ui_resources.h"
+#include "fsearch_preview.h"
 #include <glib.h>
 #include <glib/gi18n.h>
 #include <limits.h>
@@ -555,6 +556,9 @@ fsearch_application_shutdown(GApplication *app) {
         g_thread_pool_free(g_steal_pointer(&fsearch->db_pool), FALSE, TRUE);
         g_debug("[app] database thread finished.");
     }
+
+    // close the preview
+    fsearch_preview_call_close();
 
     g_clear_pointer(&fsearch->db, db_unref);
     g_clear_object(&fsearch->db_thread_cancellable);

--- a/src/fsearch_preview.c
+++ b/src/fsearch_preview.c
@@ -1,0 +1,83 @@
+/*
+   FSearch - A fast file search utility
+   Copyright © 2020 Christian Boxdörfer
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+   */
+
+#include "fsearch_preview.h"
+#include "fsearch.h"
+
+#include <gio/gio.h>
+
+#define PREVIEWER_DBUS_NAME "org.gnome.NautilusPreviewer"
+#define PREVIEWER_DBUS_IFACE "org.gnome.NautilusPreviewer"
+#define PREVIEWER_DBUS_PATH "/org/gnome/NautilusPreviewer"
+
+static void
+preview_show_file_ready_cb(GObject *source, GAsyncResult *res, gpointer user_data) {
+    g_autoptr(GError) error = NULL;
+    g_dbus_connection_call_finish(G_DBUS_CONNECTION(source), res, &error);
+
+    if (error != NULL) {
+        g_debug("Unable to call ShowFile on NautilusPreviewer: %s", error->message);
+    }
+}
+
+static void
+preview_close_ready_cb(GObject *source, GAsyncResult *res, gpointer user_data) {
+    g_autoptr(GError) error = NULL;
+    g_dbus_connection_call_finish(G_DBUS_CONNECTION(source), res, &error);
+
+    if (error != NULL) {
+        g_debug("Unable to call Close on NautilusPreviewer: %s", error->message);
+    }
+}
+
+void
+fsearch_preview_call_show_file(const gchar *uri, guint xid, gboolean close_if_already_visible) {
+    GDBusConnection *connection = g_application_get_dbus_connection(G_APPLICATION(FSEARCH_APPLICATION_DEFAULT));
+    GVariant *variant = g_variant_new("(sib)", uri, xid, close_if_already_visible);
+
+    g_dbus_connection_call(connection,
+                           PREVIEWER_DBUS_NAME,
+                           PREVIEWER_DBUS_PATH,
+                           PREVIEWER_DBUS_IFACE,
+                           "ShowFile",
+                           variant,
+                           NULL,
+                           G_DBUS_CALL_FLAGS_NONE,
+                           -1,
+                           NULL,
+                           preview_show_file_ready_cb,
+                           NULL);
+}
+
+void
+fsearch_preview_call_close(void) {
+    GDBusConnection *connection = g_application_get_dbus_connection(G_APPLICATION(FSEARCH_APPLICATION_DEFAULT));
+
+    g_dbus_connection_call(connection,
+                           PREVIEWER_DBUS_NAME,
+                           PREVIEWER_DBUS_PATH,
+                           PREVIEWER_DBUS_IFACE,
+                           "Close",
+                           NULL,
+                           NULL,
+                           G_DBUS_CALL_FLAGS_NO_AUTO_START,
+                           -1,
+                           NULL,
+                           preview_close_ready_cb,
+                           NULL);
+}

--- a/src/fsearch_preview.h
+++ b/src/fsearch_preview.h
@@ -1,0 +1,27 @@
+/*
+   FSearch - A fast file search utility
+   Copyright © 2020 Christian Boxdörfer
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+   */
+
+#pragma once
+
+#include <glib.h>
+
+void
+fsearch_preview_call_show_file(const gchar *uri, guint xid, gboolean close_if_already_visible);
+
+void
+fsearch_preview_call_close(void);

--- a/src/fsearch_window.c
+++ b/src/fsearch_window.c
@@ -508,6 +508,9 @@ on_listview_key_press_event(GtkWidget *widget, GdkEvent *event, gpointer user_da
         case GDK_KEY_KP_Enter:
             g_action_group_activate_action(group, "open", NULL);
             return GDK_EVENT_STOP;
+        case GDK_KEY_space:
+            g_action_group_activate_action(group, "preview", NULL);
+            return GDK_EVENT_STOP;
         default:
             return GDK_EVENT_PROPAGATE;
         }

--- a/src/meson.build
+++ b/src/meson.build
@@ -51,6 +51,7 @@ libfsearch_sources = [
     'fsearch_utf.c',
     'fsearch_window.c',
     'fsearch_window_actions.c',
+    'fsearch_preview.c',
 ]
 
 if build_machine.system()=='darwin'


### PR DESCRIPTION
### Description:
Press the `space` key to preview the file after selecting it.

### Prerequisites:
The `org.gnome.NautilusPreviewer` is available on the system.
![image](https://github.com/cboxdoerfer/fsearch/assets/60250462/184e1a70-f23d-4b24-ba0e-386c2fe116fb)

### Effect:
![录屏_选择区域_20230821165616](https://github.com/cboxdoerfer/fsearch/assets/60250462/a471a626-34eb-436b-9b1f-d68eefac2838)
