### PR TITLE
Set program name to fix the missing icon when running under Wayland

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -33,6 +33,7 @@ main(int argc, char *argv[]) {
     textdomain(GETTEXT_PACKAGE);
 
     g_set_application_name(_("FSearch"));
+    g_set_prgname("io.github.cboxdoerfer.FSearch");
 
     return g_application_run(G_APPLICATION(fsearch_application_new()), argc, argv);
 }


### PR DESCRIPTION
When running fsearch under Wayland, the icon in the upper left corner of window is missing.
Set the program name to fix the missing icon.