### PR TITLE
feat/search-history

### DIFF
--- a/src/fsearch_config.c
+++ b/src/fsearch_config.c
@@ -244,6 +244,11 @@ config_load(FsearchConfig *config) {
         config->exit_on_escape = config_load_boolean(key_file, "Interface", "exit_on_escape", false);
         config->show_indexing_status = config_load_boolean(key_file, "Interface", "show_indexing_status", true);
 
+        // History
+        config->enable_history = config_load_boolean(key_file, "History", "enable_history", false);
+        config->sort_history_by =
+            config_load_integer(key_file, "History", "sort_history_by", SORT_BY_NAME);
+
         // Warning Dialogs
         config->show_dialog_failed_opening = config_load_boolean(key_file, "Dialogs", "show_dialog_failed_opening", true);
 
@@ -368,6 +373,10 @@ config_load_default(FsearchConfig *config) {
     config->action_after_file_open_mouse = false;
     config->exit_on_escape = false;
     config->show_indexing_status = true;
+
+    // History
+    config->enable_history = false;
+    config->sort_history_by = SORT_BY_NAME;
 
     // Columns
     config->show_listview_icons = true;
@@ -545,6 +554,10 @@ config_save(FsearchConfig *config) {
     g_key_file_set_boolean(key_file, "Interface", "action_after_file_open_mouse", config->action_after_file_open_mouse);
     g_key_file_set_boolean(key_file, "Interface", "exit_on_escape", config->exit_on_escape);
     g_key_file_set_boolean(key_file, "Interface", "show_indexing_status", config->show_indexing_status);
+
+    // History
+    g_key_file_set_boolean(key_file, "History", "enable_history", config->enable_history);
+    g_key_file_set_integer(key_file, "History", "sort_history_by", config->sort_history_by);
 
     // Warning Dialogs
     g_key_file_set_boolean(key_file, "Dialogs", "show_dialog_failed_opening", config->show_dialog_failed_opening);

--- a/src/fsearch_config.h
+++ b/src/fsearch_config.h
@@ -33,6 +33,11 @@ typedef enum FsearchConfigActionAfterOpen {
     N_ACTIONS_AFTER_OPEN,
 } FsearchConfigActionAfterOpen;
 
+typedef enum FsearchHistorySort {
+    SORT_BY_NAME = 0,
+    SORT_BY_DATE
+}  FsearchHistorySort;
+
 typedef struct {
     bool database_config_changed;
     bool listview_config_changed;
@@ -72,6 +77,10 @@ struct _FsearchConfig {
     bool action_after_file_open_mouse;
     bool exit_on_escape;
     bool show_indexing_status;
+
+    // History
+    bool enable_history;
+    FsearchHistorySort sort_history_by;
 
     // Warning Dialogs
     bool show_dialog_failed_opening;

--- a/src/fsearch_history.c
+++ b/src/fsearch_history.c
@@ -1,0 +1,154 @@
+#include "fsearch_history.h"
+
+const char *history_file_name = ".fsearch_history.csv";
+
+static void
+sort_list_store_by_string(GtkListStore *liststore) {
+    gtk_tree_sortable_set_sort_column_id(
+        GTK_TREE_SORTABLE(liststore), 0, FALSE);
+}
+
+static void
+sort_list_store_by_date(GtkListStore *liststore) {
+    gtk_tree_sortable_set_sort_column_id(
+        GTK_TREE_SORTABLE(liststore), 1, TRUE);
+}
+
+static void
+fsearch_history_get_path(char *path) {
+    g_assert(path);
+
+    const gchar *xdg_home_dir = g_get_home_dir();
+    snprintf(path, 4096, "%s/%s", xdg_home_dir, history_file_name);
+    return;
+}
+
+static gboolean
+string_exists_in_history(GtkListStore *history, const gchar *string_to_check) {
+    GtkTreeIter iter;
+    if (gtk_tree_model_get_iter_first(GTK_TREE_MODEL(history), &iter)) {
+        do {
+            gchar *existing_string = NULL;
+            gtk_tree_model_get(GTK_TREE_MODEL(history), &iter, 0, &existing_string, -1);
+
+            if (existing_string) {
+                g_strstrip(existing_string);
+                if (g_strcmp0(existing_string, string_to_check) == 0) {
+                    g_free(existing_string);
+                    return TRUE;
+                }
+                g_free(existing_string);
+            }
+        } while (gtk_tree_model_iter_next(GTK_TREE_MODEL(history), &iter));
+    }
+    return FALSE;
+}
+
+void fsearch_history_add(GtkListStore *history, const gchar *query, int sort_by) {
+    gchar *stripped_new_string = g_strdup(query);
+    g_strstrip(stripped_new_string);
+
+    if (stripped_new_string != NULL && stripped_new_string[0] == '\0') {
+        g_free(stripped_new_string);
+        return;
+    }
+
+    if (string_exists_in_history(history, stripped_new_string)) {
+        g_free(stripped_new_string);
+        return;
+    }
+
+    GtkTreeIter iter;
+    GtkTreeIter last_iter;
+
+    gint item_count = gtk_tree_model_iter_n_children(GTK_TREE_MODEL(history), NULL);
+    if (item_count >= MAX_HISTORY_SPACE) {
+        gtk_list_store_remove(history, &last_iter);
+    }
+
+    gtk_list_store_append(history, &iter);
+    gtk_list_store_set(history, &iter, 0, stripped_new_string, 1, time(NULL), -1);
+    g_free(stripped_new_string);
+
+    if (sort_by == SORT_BY_NAME) {
+        sort_list_store_by_string(history);
+    } else {
+        sort_list_store_by_date(history);
+    }
+
+    write_liststore_to_csv(history);
+}
+
+int
+fsearch_history_exists() {
+    char path[PATH_MAX];
+    fsearch_history_get_path(path);
+    FILE *file = fopen(path, "r");
+    if (file) {
+        fclose(file);
+        return 1;
+    }
+    return 0;
+}
+
+void
+write_liststore_to_csv(GtkListStore *liststore) {
+    char path[PATH_MAX];
+    fsearch_history_get_path(path);
+    FILE *file = fopen(path, "w");
+    if (file == NULL) {
+        perror("Error opening history file");
+        return;
+    }
+
+    GtkTreeIter iter;
+    if (gtk_tree_model_get_iter_first(GTK_TREE_MODEL(liststore), &iter)) {
+        do {
+            gchar *name;
+            gint timestamp;
+
+            gtk_tree_model_get(GTK_TREE_MODEL(liststore), &iter, 0, &name, 1, &timestamp, -1);
+
+            fprintf(file, "%s,%d\n", name, timestamp);
+            g_free(name);
+        } while (gtk_tree_model_iter_next(GTK_TREE_MODEL(liststore), &iter));
+    }
+
+    fclose(file);
+}
+
+void
+write_csv_to_liststore(GtkListStore *liststore) {
+    char path[PATH_MAX];
+    fsearch_history_get_path(path);
+    FILE *file = fopen(path, "r");
+    if (file == NULL) {
+        perror("Error opening history file");
+        return;
+    }
+
+    char line[256];
+    while (fgets(line, sizeof(line), file)) {
+        gchar *name = NULL;
+        gint timestamp = 0;
+
+        line[strcspn(line, "\n")] = 0;
+
+        char *token = strtok(line, ",");
+        if (token != NULL) {
+            name = g_strdup(token);
+            token = strtok(NULL, ",");
+            if (token != NULL) {
+                timestamp = atoi(token);
+            }
+        }
+
+        GtkTreeIter iter;
+        gtk_list_store_append(liststore, &iter);
+        gtk_list_store_set(liststore, &iter, 0, name, 1, timestamp, -1);
+
+        g_free(name);
+    }
+
+    fclose(file);
+}

--- a/src/fsearch_history.h
+++ b/src/fsearch_history.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stdlib.h>
+#include <string.h>
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <time.h>
+#include "fsearch_config.h"
+#include "fsearch_limits.h"
+
+void
+fsearch_history_add(GtkListStore *history, const gchar *query, int sort_by);
+
+int
+fsearch_history_exists();
+
+void
+write_liststore_to_csv(GtkListStore *liststore);
+
+void
+write_csv_to_liststore(GtkListStore *liststore);

--- a/src/fsearch_limits.h
+++ b/src/fsearch_limits.h
@@ -22,6 +22,8 @@
 
 #define FSEARCH_THREAD_LIMIT 32
 
+#define MAX_HISTORY_SPACE 10 /* max search history queries */
+
 #ifndef PATH_MAX
 #define PATH_MAX 4096 /* max # of characters in a path name */
 #endif

--- a/src/fsearch_preferences.ui
+++ b/src/fsearch_preferences.ui
@@ -654,6 +654,91 @@
               </packing>
             </child>
             <child>
+              <!-- n-columns=1 n-rows=2 -->
+              <object class="GtkGrid">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="row-spacing">2</property>
+                <property name="column-spacing">6</property>
+                <child>
+                  <object class="GtkAlignment">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="left-padding">12</property>
+                    <child>
+                      <object class="GtkCheckButton" id="enable_history_button">
+                        <property name="label" translatable="yes">Enable history</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="draw-indicator">True</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkAlignment">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="left-padding">12</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Sort by</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBoxText" id="sort_history_by">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="active">0</property>
+                            <items>
+                              <item id="SORT_BY_NAME" translatable="yes">name</item>
+                              <item id="SORT_BY_DATE" translatable="yes">date</item>
+                            </items>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">1</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">History</property>
+              </object>
+              <packing>
+                <property name="position">1</property>
+                <property name="tab-fill">False</property>
+              </packing>
+            </child>
+            <child>
               <!-- n-columns=1 n-rows=5 -->
               <object class="GtkGrid">
                 <property name="visible">True</property>
@@ -868,7 +953,7 @@
                 </child>
               </object>
               <packing>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <child type="tab">
@@ -878,7 +963,7 @@
                 <property name="label" translatable="yes">Search</property>
               </object>
               <packing>
-                <property name="position">1</property>
+                <property name="position">2</property>
                 <property name="tab-fill">False</property>
               </packing>
             </child>
@@ -1374,7 +1459,7 @@
                 </child>
               </object>
               <packing>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
             <child type="tab">
@@ -1384,7 +1469,7 @@
                 <property name="label" translatable="yes">Database</property>
               </object>
               <packing>
-                <property name="position">2</property>
+                <property name="position">3</property>
                 <property name="tab-fill">False</property>
               </packing>
             </child>
@@ -1494,7 +1579,7 @@ Note that some window managers ignore this request and force the window to have 
 
 When a file/folder was successfully opened one of the following actions can be performed:
 	• &lt;b&gt;Nothing:&lt;/b&gt; Nothing happens.
-	• &lt;b&gt;Minimize:&lt;/b&gt; The currently selected FSearch window becomes minimized. 
+	• &lt;b&gt;Minimize:&lt;/b&gt; The currently selected FSearch window becomes minimized.
 	• &lt;b&gt;Close:&lt;/b&gt; Quit FSearch.
 
 You can configure if those actions should be triggered when the file was opened with

--- a/src/fsearch_preferences_ui.c
+++ b/src/fsearch_preferences_ui.c
@@ -60,6 +60,10 @@ typedef struct {
     GtkToggleButton *action_after_file_open_mouse;
     GtkToggleButton *show_indexing_status;
 
+    // History page
+    GtkToggleButton *enable_history_button;
+    GtkComboBox *sort_history_by;
+
     // Search page
     GtkToggleButton *auto_search_in_path_button;
     GtkToggleButton *auto_match_case_button;
@@ -505,6 +509,9 @@ preferences_ui_get_state(FsearchPreferencesInterface *ui) {
     new_config->launch_desktop_files = gtk_toggle_button_get_active(ui->launch_desktop_files_button);
     new_config->show_listview_icons = gtk_toggle_button_get_active(ui->show_icons_button);
     new_config->exclude_hidden_items = gtk_toggle_button_get_active(ui->exclude_hidden_items_button);
+    // History
+    new_config->enable_history = gtk_toggle_button_get_active(ui->enable_history_button);
+    new_config->sort_history_by = gtk_combo_box_get_active(ui->sort_history_by);
 
     g_clear_pointer(&new_config->exclude_files, g_strfreev);
     new_config->exclude_files = g_strsplit(gtk_entry_get_text(ui->exclude_files_entry), ";", -1);
@@ -657,6 +664,15 @@ preferences_ui_init(FsearchPreferencesInterface *ui, FsearchPreferencesPage page
                                                  "show_indexing_status_button",
                                                  "help_show_indexing_status",
                                                  new_config->show_indexing_status);
+
+    // History
+    ui->enable_history_button =
+        toggle_button_get(ui->builder, "enable_history_button", "help_dark_theme", new_config->enable_history);
+
+    ui->sort_history_by = GTK_COMBO_BOX(
+        builder_init_widget(ui->builder, "sort_history_by", "help_action_after_open"));
+
+    gtk_combo_box_set_active(ui->sort_history_by, new_config->sort_history_by);
 
     // Search page
     ui->auto_search_in_path_button =

--- a/src/fsearch_window.h
+++ b/src/fsearch_window.h
@@ -27,6 +27,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "fsearch_list_view.h"
 #include "fsearch_query.h"
 #include "fsearch_statusbar.h"
+#include "fsearch_history.h"
 
 G_BEGIN_DECLS
 

--- a/src/fsearch_window.ui
+++ b/src/fsearch_window.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.40.0 
+<!-- Generated with glade 3.40.0
 
-FSearch - 
+FSearch -
 Copyright (C) Christian Boxdörfer
 
 This program is free software; you can redistribute it and/or
@@ -41,6 +41,152 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </object>
   <object class="GtkPopoverMenu" id="main_menu_popover">
     <property name="can-focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="margin-start">6</property>
+        <property name="margin-end">6</property>
+        <property name="margin-top">6</property>
+        <property name="margin-bottom">6</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="text" translatable="yes">FSearch Online</property>
+            <property name="menu-name">main</property>
+            <property name="inverted">True</property>
+            <property name="centered">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="text" translatable="yes">Donate</property>
+            <property name="menu-name">donate_menu</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="action-name">app.forum</property>
+            <property name="text" translatable="yes">Forum</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="action-name">app.bug_report</property>
+            <property name="text" translatable="yes">Bug Reports and Feature Requests</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="action-name">app.online_help</property>
+            <property name="text" translatable="yes">Help</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="submenu">online_menu</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="margin-start">6</property>
+        <property name="margin-end">6</property>
+        <property name="margin-top">6</property>
+        <property name="margin-bottom">6</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="text" translatable="yes">Donate</property>
+            <property name="menu-name">online_menu</property>
+            <property name="inverted">True</property>
+            <property name="centered">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="action-name">app.donate_github</property>
+            <property name="text" translatable="yes">GitHub Sponsors</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="action-name">app.donate_paypal</property>
+            <property name="text" translatable="yes">PayPal</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="submenu">donate_menu</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
@@ -336,155 +482,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </object>
       <packing>
         <property name="submenu">main</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="margin-start">6</property>
-        <property name="margin-end">6</property>
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">6</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="text" translatable="yes">FSearch Online</property>
-            <property name="menu-name">main</property>
-            <property name="inverted">True</property>
-            <property name="centered">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="text" translatable="yes">Donate</property>
-            <property name="menu-name">donate_menu</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="action-name">app.forum</property>
-            <property name="text" translatable="yes">Forum</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="action-name">app.bug_report</property>
-            <property name="text" translatable="yes">Bug Reports and Feature Requests</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="action-name">app.online_help</property>
-            <property name="text" translatable="yes">Help</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">4</property>
-          </packing>
-        </child>
-      </object>
-      <packing>
-        <property name="submenu">online_menu</property>
-        <property name="position">1</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="margin-start">6</property>
-        <property name="margin-end">6</property>
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">6</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="text" translatable="yes">Donate</property>
-            <property name="menu-name">online_menu</property>
-            <property name="inverted">True</property>
-            <property name="centered">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="action-name">app.donate_github</property>
-            <property name="text" translatable="yes">GitHub Sponsors</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="action-name">app.donate_paypal</property>
-            <property name="text" translatable="yes">PayPal</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-      </object>
-      <packing>
-        <property name="submenu">donate_menu</property>
-        <property name="position">2</property>
+        <property name="position">3</property>
       </packing>
     </child>
   </object>
+  <object class="GtkEntryCompletion" id="search_completion"/>
   <template class="FsearchApplicationWindow" parent="GtkApplicationWindow">
     <property name="name">application_window</property>
     <property name="can-focus">False</property>
@@ -583,8 +585,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                     <property name="primary-icon-sensitive">False</property>
                     <property name="secondary-icon-sensitive">False</property>
                     <property name="placeholder-text" translatable="yes">Search…</property>
+                    <property name="completion">search_completion</property>
                     <signal name="activate" handler="on_search_entry_activate" object="FsearchApplicationWindow" swapped="no"/>
                     <signal name="changed" handler="on_search_entry_changed" object="FsearchApplicationWindow" swapped="no"/>
+                    <signal name="button-press-event" handler="on_search_entry_button_press_event" object="FsearchApplicationWindow" swapped="no"/>
                     <signal name="key-press-event" handler="on_search_entry_key_press_event" object="FsearchApplicationWindow" swapped="no"/>
                   </object>
                   <packing>

--- a/src/meson.build
+++ b/src/meson.build
@@ -52,6 +52,7 @@ libfsearch_sources = [
     'fsearch_window.c',
     'fsearch_window_actions.c',
     'fsearch_preview.c',
+    'fsearch_history.c',
 ]
 
 if build_machine.system()=='darwin'


### PR DESCRIPTION
Hi!, 

Some long time ago, I have added a basic search history to your project, cause I needed it, but have never considered to publish the code. 

I have added some basic UI, which is not perfect. If you like the solution I would improve the MR so it would be merge ready. I am no gtk/c programmer but I tried my best, so feedback is welcome.

How it works:
- History is saved to a .csv file which is located in the home directory.
- It stores the search query and the timestamp so you could sort by both.
- The completions open when you type something or double click on the search entry.

Whats not working:
- The UI broke the current one, if you click to add a path to the database, the wrong index is called in the preferences settings. 
- Double click does not work on the initial state, you have to type something before. E.g. just type a space, remove it and then you can double click. Not sure why its not working, might be some search entry property, which cannot be overwritten?.

