### PR TITLE
Rename Selection Feature

### DIFF
--- a/src/fsearch_file_utils.c
+++ b/src/fsearch_file_utils.c
@@ -167,6 +167,27 @@ fsearch_file_utils_trash(const char *path, GString *error_messages) {
     return file_remove_or_trash(path, false, error_messages);
 }
 
+bool
+fsearch_file_utils_rename(const char *path, const char *new_name, GString *error_messages) {
+    g_autoptr(GFile) file = g_file_new_for_path(path);
+    if (!file) {
+        add_error_message_with_format(error_messages,
+                                      C_("Will be followed by the path of the file.", "Error when renaming file"),
+                                      path,
+                                      _("Failed to get path"));
+        return false;
+    }
+
+    g_autoptr(GError) error = NULL;
+    g_file_set_display_name(file, new_name, NULL, &error);
+
+    if (error) {
+        add_error_message(error_messages, error->message);
+        return false;
+    }
+    return true;
+}
+
 // Structure to store files (`uris`) which should be opened with the application described by `app_info`
 typedef struct {
     GAppInfo *app_info;

--- a/src/fsearch_file_utils.h
+++ b/src/fsearch_file_utils.h
@@ -35,6 +35,9 @@ fsearch_file_utils_trash(const char *path, GString *error_messages);
 bool
 fsearch_file_utils_remove(const char *path, GString *error_messages);
 
+bool
+fsearch_file_utils_rename(const char *path, const char *new_name, GString *error_messages);
+
 void
 fsearch_file_utils_open_path_list(GList *paths,
                                   bool launch_desktop_files,

--- a/src/fsearch_rename_selection.ui
+++ b/src/fsearch_rename_selection.ui
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.40.0 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <object class="GtkDialog" id="FsearchRenameFileDialog">
+    <property name="can-focus">False</property>
+    <property name="modal">True</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="type-hint">dialog</property>
+    <property name="gravity">center</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="button1">
+                <property name="label" translatable="yes">Rename</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button2">
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="new_name_entry">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="width-chars">80</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-5">button1</action-widget>
+      <action-widget response="-6">button2</action-widget>
+    </action-widgets>
+  </object>
+</interface>

--- a/src/fsearch_window.c
+++ b/src/fsearch_window.c
@@ -504,6 +504,9 @@ on_listview_key_press_event(GtkWidget *widget, GdkEvent *event, gpointer user_da
         case GDK_KEY_Delete:
             g_action_group_activate_action(group, "move_to_trash", NULL);
             return GDK_EVENT_STOP;
+        case GDK_KEY_F2:
+            g_action_group_activate_action(group, "rename_selection", NULL);
+            return GDK_EVENT_STOP;
         case GDK_KEY_Return:
         case GDK_KEY_KP_Enter:
             g_action_group_activate_action(group, "open", NULL);

--- a/src/fsearch_window_actions.c
+++ b/src/fsearch_window_actions.c
@@ -38,6 +38,7 @@
 #include "fsearch_file_utils.h"
 #include "fsearch_list_view.h"
 #include "fsearch_statusbar.h"
+#include "fsearch_string_utils.h"
 #include "fsearch_ui_utils.h"
 #include "fsearch_window_actions.h"
 #include "fsearch_preview.h"
@@ -171,6 +172,24 @@ append_name_to_string(gpointer key, gpointer value, gpointer user_data) {
 }
 
 static void
+increment_condition_tally(guint *tally,
+                          FsearchDatabaseEntry *entry,
+                          bool (*predicate_func)(FsearchDatabaseEntry *)) {
+    if (!tally || !entry || !predicate_func) {
+        return;
+    }
+
+    if (predicate_func(entry)) {
+        ++(*tally);
+    }
+}
+
+static void
+increment_folder_tally(gpointer key, gpointer value, gpointer user_data) {
+    increment_condition_tally((guint *) user_data, value, db_entry_is_folder);
+}
+
+static void
 fsearch_delete_selection(GSimpleAction *action, GVariant *variant, bool delete, gpointer user_data) {
     FsearchApplicationWindow *self = user_data;
 
@@ -239,6 +258,120 @@ save_fail:
     }
 }
 
+static gboolean
+rename_on_dialog_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data) {
+    if (event->keyval == GDK_KEY_Escape) {
+        gtk_dialog_response(GTK_DIALOG(widget), GTK_RESPONSE_CANCEL);
+        return TRUE;
+    } else if (event->keyval == GDK_KEY_Return) {
+        gtk_dialog_response(GTK_DIALOG(widget), GTK_RESPONSE_OK);
+        return TRUE;
+    }
+    return FALSE;
+}
+
+typedef struct {
+    gint range_end_pos;
+    gboolean is_first_focus;
+} FsearchRenameFocusContext;
+
+// Replicate the behavior of Nautilus, where the initial selection excludes
+// the filename extension, when present
+static gboolean
+rename_on_entry_focus_in(GtkWidget *entry, GdkEvent *event, gpointer user_data) {
+    FsearchRenameFocusContext *context = (FsearchRenameFocusContext *) user_data;
+    if (context->is_first_focus) {
+        gtk_editable_select_region(GTK_EDITABLE(entry), 0, context->range_end_pos);
+        context->is_first_focus = FALSE;
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+static void
+fsearch_rename_selection(GSimpleAction *action, GVariant *variant, bool delete, gpointer user_data) {
+    FsearchApplicationWindow *self = user_data;
+    g_assert(FSEARCH_IS_APPLICATION_WINDOW(self));
+
+    const guint num_selected_rows = fsearch_application_window_get_num_selected(self);
+    if (num_selected_rows > 1) {
+        g_autoptr(GString) warning_message = g_string_new(NULL);
+        g_string_printf(warning_message, _("Renaming multiple entries at one time is not currently supported."));
+        ui_utils_run_gtk_dialog(GTK_WIDGET(self),
+                                GTK_MESSAGE_INFO,
+                                GTK_BUTTONS_OK,
+                                _("Renaming selection…"),
+                                warning_message->str);
+        return;
+    }
+
+    GList *file_list = NULL;
+    GtkDialog *dialog = NULL;
+
+    fsearch_application_window_selection_for_each(self, prepend_full_path_to_list, &file_list);
+    g_assert(file_list);
+    const gchar *original_name = g_path_get_basename(file_list->data);
+
+    GtkBuilder * builder = gtk_builder_new_from_resource("/io/github/cboxdoerfer/fsearch/ui/fsearch_rename_selection.ui");
+
+    GtkEntry * entry = GTK_ENTRY(gtk_builder_get_object(builder, "new_name_entry"));
+    g_assert(entry);
+    gtk_entry_set_text(entry, original_name);
+
+    const char *extension_pointer = fsearch_string_get_extension(original_name);
+    gint extension_index = (strlen(extension_pointer)) ? extension_index = extension_pointer - original_name - 1 : -1;
+    FsearchRenameFocusContext rename_context = { .is_first_focus = true, .range_end_pos = extension_index };
+    g_signal_connect(entry, "focus-in-event", G_CALLBACK(rename_on_entry_focus_in), &rename_context);
+
+    dialog = GTK_DIALOG(gtk_builder_get_object(builder, "FsearchRenameFileDialog"));
+    g_assert(dialog);
+
+    guint folder_tally = 0;
+    fsearch_application_window_selection_for_each(self, increment_folder_tally, &folder_tally);
+    gtk_window_set_title(GTK_WINDOW(dialog), folder_tally ? _("Rename Folder") : _("Rename File"));
+
+    g_signal_connect(dialog, "key-press-event", G_CALLBACK(rename_on_dialog_key_press), NULL);
+    gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(self));
+    gint response = gtk_dialog_run(GTK_DIALOG(dialog));
+
+    if (response == GTK_RESPONSE_OK) {
+        const gchar *new_name = gtk_entry_get_text(entry);
+        if (strlen(new_name) && strcmp(new_name, original_name)) {
+            g_autoptr(GString) error_message = g_string_new(NULL);
+
+            if (fsearch_file_utils_rename(file_list->data, new_name, error_message)) {
+                g_autoptr(GString) secondary_message = g_string_new(NULL);
+                g_string_printf(secondary_message, _("[Original name]: %s\n[New name]: %s\n\n%s"),
+                                original_name,
+                                new_name,
+                                _("The database needs to be updated before it becomes aware of this change! "
+                                  "This will be fixed with future updates."));
+                ui_utils_run_gtk_dialog_async(GTK_WIDGET(self),
+                                              GTK_MESSAGE_INFO,
+                                              GTK_BUTTONS_OK,
+                                              _("Renamed selection."),
+                                              secondary_message->str,
+                                              G_CALLBACK(gtk_widget_destroy),
+                                              NULL);
+            }
+
+            if (error_message->len > 0) {
+                ui_utils_run_gtk_dialog_async(GTK_WIDGET(self),
+                                              GTK_MESSAGE_WARNING,
+                                              GTK_BUTTONS_OK,
+                                              _("Something went wrong."),
+                                              error_message->str,
+                                              G_CALLBACK(gtk_widget_destroy),
+                                              NULL);
+            }
+        }
+    }
+
+    gtk_widget_destroy(GTK_WIDGET(dialog));
+    g_list_free_full(g_steal_pointer(&file_list), (GDestroyNotify)g_free);
+}
+
 static void
 fsearch_window_action_file_properties(GSimpleAction *action, GVariant *variant, gpointer user_data) {
     FsearchApplicationWindow *self = user_data;
@@ -292,6 +425,11 @@ fsearch_window_action_file_properties(GSimpleAction *action, GVariant *variant, 
 static void
 fsearch_window_action_move_to_trash(GSimpleAction *action, GVariant *variant, gpointer user_data) {
     fsearch_delete_selection(action, variant, false, user_data);
+}
+
+static void
+fsearch_window_action_file_rename(GSimpleAction *action, GVariant *variant, gpointer user_data) {
+    fsearch_rename_selection(action, variant, false, user_data);
 }
 
 static void
@@ -865,6 +1003,7 @@ static GActionEntry FsearchWindowActions[] = {
     {"file_properties", fsearch_window_action_file_properties},
     {"move_to_trash", fsearch_window_action_move_to_trash},
     {"delete_selection", fsearch_window_action_delete},
+    {"rename_selection", fsearch_window_action_file_rename},
     {"select_all", fsearch_window_action_select_all},
     {"deselect_all", fsearch_window_action_deselect_all},
     {"invert_selection", fsearch_window_action_invert_selection},
@@ -917,6 +1056,7 @@ fsearch_window_actions_update(FsearchApplicationWindow *self) {
     action_set_enabled(group, "copy_as_text_path_clipboard", num_rows_selected);
     action_set_enabled(group, "cut_clipboard", num_rows_selected);
     action_set_enabled(group, "delete_selection", FALSE);
+    action_set_enabled(group, "rename_selection", num_rows_selected >= 1 ? TRUE : FALSE);
     action_set_enabled(group, "file_properties", has_file_manager_on_bus && num_rows_selected >= 1 ? TRUE : FALSE);
     action_set_enabled(group, "move_to_trash", num_rows_selected);
     action_set_enabled(group, "open", num_rows_selected);

--- a/src/gresource.xml
+++ b/src/gresource.xml
@@ -4,6 +4,7 @@
         <file compressed="true">fsearch_filter_editor.ui</file>
         <file compressed="true">fsearch_overlay.ui</file>
         <file compressed="true">fsearch_preferences.ui</file>
+        <file compressed="true">fsearch_rename_selection.ui</file>
         <file compressed="true">fsearch_statusbar.ui</file>
         <file compressed="true">fsearch_window.ui</file>
         <file compressed="true">menus.ui</file>

--- a/src/menus.ui
+++ b/src/menus.ui
@@ -248,6 +248,11 @@
             -->
         </section>
         <section id="fsearch_listview_menu_file_properties_section">
+            <item>
+                <attribute name="label" translatable="yes">Rename</attribute>
+                <attribute name="action">win.rename_selection</attribute>
+                <attribute name="accel">F2</attribute>
+            </item>
             <!--
             <item>
                 <attribute name="label" translatable="yes">Properties…</attribute>


### PR DESCRIPTION
**Allows the user to rename the selected file or folder by choosing "Rename" from the right-click context menu or by pressing F2.**

- Supports single-entry selections only (notifies user of this when invoked on multi-entry selections)
- Similar to "Move to Trash", the user is notified that the database won't be aware of changes until the next update

I implemented this feature for my personal use, but think others might find it useful, too. I remain open to making changes/feedback.

Thank you to all who contribute to FSearch.