### PR TITLE
New preference added to enable file managers to open with selected file highlighted automatically

### DIFF
--- a/src/fsearch_config.c
+++ b/src/fsearch_config.c
@@ -228,6 +228,7 @@ config_load(FsearchConfig *config) {
         config->restore_sort_order = config_load_boolean(key_file, "Interface", "restore_sort_order", true);
         config->restore_column_config = config_load_boolean(key_file, "Interface", "restore_column_configuration", true);
         config->double_click_path = config_load_boolean(key_file, "Interface", "double_click_path", false);
+        config->open_folder_selects_active_file = config_load_boolean(key_file, "Interface", "open_folder_selects_active_file", false);
         config->enable_list_tooltips = config_load_boolean(key_file, "Interface", "enable_list_tooltips", true);
         config->enable_dark_theme = config_load_boolean(key_file, "Interface", "enable_dark_theme", false);
         config->show_menubar = config_load_boolean(key_file, "Interface", "show_menubar", true);
@@ -358,6 +359,7 @@ config_load_default(FsearchConfig *config) {
     config->restore_column_config = true;
     config->restore_sort_order = true;
     config->double_click_path = false;
+    config->open_folder_selects_active_file = false;
     config->show_menubar = true;
     config->show_statusbar = true;
     config->show_filter = true;
@@ -530,6 +532,7 @@ config_save(FsearchConfig *config) {
     g_key_file_set_boolean(key_file, "Interface", "restore_column_configuration", config->restore_column_config);
     g_key_file_set_boolean(key_file, "Interface", "restore_sort_order", config->restore_sort_order);
     g_key_file_set_boolean(key_file, "Interface", "double_click_path", config->double_click_path);
+    g_key_file_set_boolean(key_file, "Interface", "open_folder_selects_active_file", config->open_folder_selects_active_file);
     g_key_file_set_boolean(key_file, "Interface", "enable_list_tooltips", config->enable_list_tooltips);
     g_key_file_set_boolean(key_file, "Interface", "enable_dark_theme", config->enable_dark_theme);
     g_key_file_set_boolean(key_file, "Interface", "show_menubar", config->show_menubar);

--- a/src/fsearch_config.h
+++ b/src/fsearch_config.h
@@ -67,6 +67,7 @@ struct _FsearchConfig {
     bool restore_column_config;
     bool restore_sort_order;
     bool double_click_path;
+    bool open_folder_selects_active_file;
     FsearchConfigActionAfterOpen action_after_file_open;
     bool action_after_file_open_keyboard;
     bool action_after_file_open_mouse;

--- a/src/fsearch_file_utils.h
+++ b/src/fsearch_file_utils.h
@@ -45,6 +45,9 @@ fsearch_file_utils_open_path_list(GList *paths,
 bool
 fsearch_file_utils_open_path_list_with_command(GList *paths, const char *cmd, GString *error_message);
 
+bool
+fsearch_file_utils_open_path_list_with_command_internal(GList *paths, const char *cmd, GString *error_message, bool use_full_path);
+
 gchar *
 fsearch_file_utils_get_file_type(const gchar *name, gboolean is_dir);
 

--- a/src/fsearch_preferences.ui
+++ b/src/fsearch_preferences.ui
@@ -449,6 +449,21 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="open_folder_selects_active_file_button">
+                                <property name="label" translatable="yes">Open Folder selects active file</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="has-tooltip">True</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">6</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkCheckButton" id="single_click_open_button">
                                 <property name="label" translatable="yes">Single click to open</property>
                                 <property name="visible">True</property>
@@ -460,7 +475,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">6</property>
+                                <property name="position">7</property>
                               </packing>
                             </child>
                             <child>
@@ -475,7 +490,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">7</property>
+                                <property name="position">8</property>
                               </packing>
                             </child>
                           </object>
@@ -1618,6 +1633,30 @@ If enabled, double clicking in the path column will open the selected path.</pro
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkLabel" id="help_open_folder_selects_active_file">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">&lt;b&gt;Open Folder selects active file:&lt;/b&gt;
+
+If enabled, "Open Folder" (from the right-click menu or by pressing Ctrl-Return) will pass the full file path to the file manager instead of just the path of the containing folder.
+
+By default an attempt is made to automatically detect your file manager, but you can override this by adding the following to your ~/.config/fsearch/fsearch.conf :
+
+[Applications]
+folder_open_cmd=dolphin --select {path_full}
+
+({path_full} will be automatically escaped)</property>
+                    <property name="use-markup">True</property>
+                    <property name="wrap">True</property>
+                    <property name="selectable">True</property>
+                  </object>
+                  <packing>
+                    <property name="name">page11</property>
+                    <property name="title">page11</property>
+                    <property name="position">11</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkLabel" id="help_single_click_open">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -1629,9 +1668,9 @@ If enabled, a single click will open the selected file/folder. If you only want 
                     <property name="selectable">True</property>
                   </object>
                   <packing>
-                    <property name="name">page11</property>
-                    <property name="title">page11</property>
-                    <property name="position">11</property>
+                    <property name="name">page12</property>
+                    <property name="title">page12</property>
+                    <property name="position">12</property>
                   </packing>
                 </child>
                 <child>
@@ -1646,9 +1685,9 @@ If enabled, the path that is currently being indexed is displayed in the statusb
                     <property name="selectable">True</property>
                   </object>
                   <packing>
-                    <property name="name">page12</property>
-                    <property name="title">page12</property>
-                    <property name="position">12</property>
+                    <property name="name">page13</property>
+                    <property name="title">page13</property>
+                    <property name="position">13</property>
                   </packing>
                 </child>
                 <child>
@@ -1663,9 +1702,9 @@ If enabled, a warning dialog is displayed when a file or folder failed to open.<
                     <property name="selectable">True</property>
                   </object>
                   <packing>
-                    <property name="name">page13</property>
-                    <property name="title">page13</property>
-                    <property name="position">13</property>
+                    <property name="name">page14</property>
+                    <property name="title">page14</property>
+                    <property name="position">14</property>
                   </packing>
                 </child>
                 <child>
@@ -1680,9 +1719,9 @@ If enabled, search terms containing path separators (i.e. "/") will be automatic
                     <property name="selectable">True</property>
                   </object>
                   <packing>
-                    <property name="name">page14</property>
-                    <property name="title">page14</property>
-                    <property name="position">14</property>
+                    <property name="name">page15</property>
+                    <property name="title">page15</property>
+                    <property name="position">15</property>
                   </packing>
                 </child>
                 <child>
@@ -1697,9 +1736,9 @@ If enabled, search terms containing at least one upper case character will trigg
                     <property name="selectable">True</property>
                   </object>
                   <packing>
-                    <property name="name">page15</property>
-                    <property name="title">page15</property>
-                    <property name="position">15</property>
+                    <property name="name">page16</property>
+                    <property name="title">page16</property>
+                    <property name="position">16</property>
                   </packing>
                 </child>
                 <child>

--- a/src/fsearch_preferences_ui.c
+++ b/src/fsearch_preferences_ui.c
@@ -48,6 +48,7 @@ typedef struct {
     GtkToggleButton *restore_sort_order_button;
     GtkToggleButton *restore_column_config_button;
     GtkToggleButton *double_click_path_button;
+    GtkToggleButton *open_folder_selects_active_file_button;
     GtkToggleButton *single_click_open_button;
     GtkToggleButton *launch_desktop_files_button;
     GtkToggleButton *show_icons_button;
@@ -481,6 +482,7 @@ preferences_ui_get_state(FsearchPreferencesInterface *ui) {
     new_config->restore_column_config = gtk_toggle_button_get_active(ui->restore_column_config_button);
     new_config->restore_sort_order = gtk_toggle_button_get_active(ui->restore_sort_order_button);
     new_config->double_click_path = gtk_toggle_button_get_active(ui->double_click_path_button);
+    new_config->open_folder_selects_active_file = gtk_toggle_button_get_active(ui->open_folder_selects_active_file_button);
     new_config->enable_list_tooltips = gtk_toggle_button_get_active(ui->show_tooltips_button);
     new_config->restore_window_size = gtk_toggle_button_get_active(ui->restore_win_size_button);
     new_config->exit_on_escape = gtk_toggle_button_get_active(ui->exit_on_escape_button);
@@ -602,6 +604,11 @@ preferences_ui_init(FsearchPreferencesInterface *ui, FsearchPreferencesPage page
                                                      "double_click_path_button",
                                                      "help_double_click_path",
                                                      new_config->double_click_path);
+
+    ui->open_folder_selects_active_file_button = toggle_button_get(ui->builder,
+                                                                   "open_folder_selects_active_file_button",
+                                                                   "help_open_folder_selects_active_file",
+                                                                   new_config->open_folder_selects_active_file);
 
     ui->single_click_open_button = toggle_button_get(ui->builder,
                                                      "single_click_open_button",


### PR DESCRIPTION
Hi,

I made code changes to add a new "Open Folder selects active file" preference (off by default) along with help text to explain it further.

Previously I was having to do Ctrl-Return, and then in my file manager do Ctrl-F and search for the file to jump to the file in question (_at least, for directories with large numbers of files_). I wanted to just be able to do the equivalent of opening the file manager directly to the path of the file so the file would automatically be selected, saving a lot of additional keystrokes. I love fsearch, and this behavior was the one thing I really missed from locate32 on the windows side of things. I started making changes before I saw the idea thread, so I decided to just keep going since this way it would hopefully be more obvious to new users how they could get this working.

When the new option is selected, an attempt is made to figure out the default file manager in use, and then the full file path is passed to it. The help text also explains how people can add a .conf option to override this behavior if their file manager has specific needs.

Also, I'm very inexperienced in doing pull requests and contributing on github, so apologies in advance if I messed anything up in submitting this.