### PR TITLE
Added new Applications preference tab with File Manager option

### DIFF
--- a/src/fsearch_preferences.ui
+++ b/src/fsearch_preferences.ui
@@ -1388,6 +1388,110 @@
                 <property name="tab-fill">False</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkFrame">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
+                    <child>
+                      <object class="GtkAlignment">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">12</property>
+                        <property name="margin-top">4</property>
+                        <property name="bottom-padding">6</property>
+                        <property name="right-padding">6</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">File Manager:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkEntry" id="folder_open_cmd_entry">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="has-tooltip">True</property>
+                                    <property name="placeholder-text" translatable="yes">e.g. dolphin --select {path_full}</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Applications:</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Applications</property>
+              </object>
+              <packing>
+                <property name="position">3</property>
+                <property name="tab-fill">False</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">True</property>
@@ -2057,6 +2161,31 @@ If enabled, FSearch exits when the Escape key is pressed instead of the window b
                     <property name="name">page35</property>
                     <property name="title">page35</property>
                     <property name="position">35</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="help_folder_open_cmd">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">&lt;b&gt;File Manager:&lt;/b&gt;
+
+By default, when you choose "Open Folder" or press Ctrl-Return, the parent folder of the selected entry is passed on to the default file opener.
+
+If you would instead like to have your file manager open with the selected file highlighted, enter the parameters for your file manager here.
+
+For example, for Dolphin, you would enter:
+
+dolphin --select {path_full}
+
+({path_full} will be automatically escaped)</property>
+                    <property name="use-markup">True</property>
+                    <property name="wrap">True</property>
+                    <property name="selectable">True</property>
+                  </object>
+                  <packing>
+                    <property name="name">page36</property>
+                    <property name="title">page36</property>
+                    <property name="position">36</property>
                   </packing>
                 </child>
               </object>

--- a/src/fsearch_preferences_ui.c
+++ b/src/fsearch_preferences_ui.c
@@ -105,6 +105,9 @@ typedef struct {
     GtkToggleButton *exclude_hidden_items_button;
     GtkEntry *exclude_files_entry;
     gchar *exclude_files_str;
+
+    // Applications page
+    GtkEntry *folder_open_cmd_entry;
 } FsearchPreferencesInterface;
 
 enum { COLUMN_NAME, NUM_COLUMNS };
@@ -509,6 +512,12 @@ preferences_ui_get_state(FsearchPreferencesInterface *ui) {
     g_clear_pointer(&new_config->exclude_files, g_strfreev);
     new_config->exclude_files = g_strsplit(gtk_entry_get_text(ui->exclude_files_entry), ";", -1);
 
+    g_clear_pointer(&new_config->folder_open_cmd, g_free);
+    const char *folder_open_cmd_text = gtk_entry_get_text(ui->folder_open_cmd_entry);
+    if (folder_open_cmd_text && strlen(folder_open_cmd_text) > 0) {
+        new_config->folder_open_cmd = g_strdup(folder_open_cmd_text);
+    }
+
     if (new_config->indexes) {
         g_list_free_full(g_steal_pointer(&new_config->indexes), (GDestroyNotify)fsearch_index_free);
     }
@@ -785,6 +794,12 @@ preferences_ui_init(FsearchPreferencesInterface *ui, FsearchPreferencesPage page
     if (new_config->exclude_files) {
         ui->exclude_files_str = g_strjoinv(";", new_config->exclude_files);
         gtk_entry_set_text(ui->exclude_files_entry, ui->exclude_files_str);
+    }
+
+    // Applications page
+    ui->folder_open_cmd_entry = GTK_ENTRY(builder_init_widget(ui->builder, "folder_open_cmd_entry", "help_folder_open_cmd"));
+    if (new_config->folder_open_cmd) {
+        gtk_entry_set_text(ui->folder_open_cmd_entry, new_config->folder_open_cmd);
     }
 }
 

--- a/src/fsearch_preferences_ui.h
+++ b/src/fsearch_preferences_ui.h
@@ -25,6 +25,7 @@ typedef enum FsearchPreferencesPage {
     PREF_PAGE_GENERAL = 0,
     PREF_PAGE_SEARCH,
     PREF_PAGE_DATABASE,
+    PREF_PAGE_APPLICATIONS,
     N_PREF_PAGES,
 
 } FsearchPreferencesPage;


### PR DESCRIPTION
This adds a new "Applications" tab to Preferences where users could configure their file manager, along with help text. If the field is populated, then it populates:

[Applications]
folder_open_cmd=...

...in fsearch.conf. If the field is not populated, the normal behavior of opening the parent folder is followed.

I was confused about how to make Ctrl-Return work the way I wanted till I found that ideas thread, so I wanted to make it simpler for others to realize they could customize that.