### PR TITLE
Added context menu action to compare two files

### DIFF
--- a/src/fsearch.c
+++ b/src/fsearch.c
@@ -31,6 +31,7 @@
 #include "fsearch_preferences_ui.h"
 #include "fsearch_ui_utils.h"
 #include "fsearch_window.h"
+#include "fsearch_window_actions.h"
 #include "icon_resources.h"
 #include "ui_resources.h"
 #include "fsearch_preview.h"
@@ -479,6 +480,7 @@ on_preferences_ui_finished(FsearchConfig *new_config) {
         }
         if (config_diff.listview_config_changed) {
             fsearch_application_window_update_listview_config(window);
+            fsearch_window_actions_update(window);
         }
     }
 

--- a/src/fsearch_config.c
+++ b/src/fsearch_config.c
@@ -246,9 +246,11 @@ config_load(FsearchConfig *config) {
 
         // Warning Dialogs
         config->show_dialog_failed_opening = config_load_boolean(key_file, "Dialogs", "show_dialog_failed_opening", true);
+        config->show_dialog_failed_diff = config_load_boolean(key_file, "Dialogs", "show_dialog_failed_diff", true);
 
         // Applications
         config->folder_open_cmd = config_load_string(key_file, "Applications", "folder_open_cmd", NULL);
+        config->diff_tool_cmd = config_load_string(key_file, "Applications", "diff_tool_cmd", NULL);
 
         // Window
         config->restore_window_size = config_load_boolean(key_file, "Interface", "restore_window_size", false);
@@ -368,6 +370,7 @@ config_load_default(FsearchConfig *config) {
     config->action_after_file_open_mouse = false;
     config->exit_on_escape = false;
     config->show_indexing_status = true;
+    config->diff_tool_cmd = NULL;
 
     // Columns
     config->show_listview_icons = true;
@@ -395,6 +398,7 @@ config_load_default(FsearchConfig *config) {
 
     // Warning Dialogs
     config->show_dialog_failed_opening = true;
+    config->show_dialog_failed_diff = true;
 
     // Window
     config->restore_window_size = false;
@@ -548,6 +552,7 @@ config_save(FsearchConfig *config) {
 
     // Warning Dialogs
     g_key_file_set_boolean(key_file, "Dialogs", "show_dialog_failed_opening", config->show_dialog_failed_opening);
+    g_key_file_set_boolean(key_file, "Dialogs", "show_dialog_failed_diff", config->show_dialog_failed_diff);
 
     // Window
     g_key_file_set_boolean(key_file, "Interface", "restore_window_size", config->restore_window_size);
@@ -585,6 +590,11 @@ config_save(FsearchConfig *config) {
     // Applications
     if (config->folder_open_cmd) {
         g_key_file_set_string(key_file, "Applications", "folder_open_cmd", config->folder_open_cmd);
+    }
+    if (config->diff_tool_cmd && *config->diff_tool_cmd) {
+        g_key_file_set_string(key_file, "Applications", "diff_tool_cmd", config->diff_tool_cmd);
+    } else {
+        g_key_file_remove_key(key_file, "Applications", "diff_tool_cmd", NULL);
     }
 
     // Search
@@ -737,7 +747,9 @@ config_cmp(FsearchConfig *c1, FsearchConfig *c2) {
         result.search_config_changed = true;
     }
     if (c1->highlight_search_terms != c2->highlight_search_terms || c1->show_listview_icons != c2->show_listview_icons
-        || c1->single_click_open != c2->single_click_open || c1->enable_list_tooltips != c2->enable_list_tooltips) {
+        || c1->single_click_open != c2->single_click_open || c1->enable_list_tooltips != c2->enable_list_tooltips
+        || g_strcmp0(c1->folder_open_cmd, c2->folder_open_cmd) != 0
+        || g_strcmp0(c1->diff_tool_cmd, c2->diff_tool_cmd) != 0) {
         result.listview_config_changed = true;
     }
 
@@ -772,6 +784,9 @@ config_copy(FsearchConfig *config) {
     if (config->folder_open_cmd) {
         copy->folder_open_cmd = g_strdup(config->folder_open_cmd);
     }
+    if (config->diff_tool_cmd) {
+        copy->diff_tool_cmd = g_strdup(config->diff_tool_cmd);
+    }
     if (config->sort_by) {
         copy->sort_by = g_strdup(config->sort_by);
     }
@@ -795,6 +810,7 @@ config_free(FsearchConfig *config) {
     g_assert(config);
 
     g_clear_pointer(&config->folder_open_cmd, free);
+    g_clear_pointer(&config->diff_tool_cmd, free);
     g_clear_pointer(&config->sort_by, free);
     g_clear_pointer(&config->filters, fsearch_filter_manager_free);
     if (config->indexes) {

--- a/src/fsearch_config.h
+++ b/src/fsearch_config.h
@@ -52,6 +52,7 @@ struct _FsearchConfig {
 
     // Applications
     char *folder_open_cmd;
+    char *diff_tool_cmd;
 
     // Window
     bool restore_window_size;
@@ -75,6 +76,7 @@ struct _FsearchConfig {
 
     // Warning Dialogs
     bool show_dialog_failed_opening;
+    bool show_dialog_failed_diff;
 
     // View menu
     bool show_menubar;

--- a/src/fsearch_listview_popup.c
+++ b/src/fsearch_listview_popup.c
@@ -178,6 +178,17 @@ listview_popup_menu(GtkWidget *widget, FsearchDatabaseView *db_view) {
     add_file_properties_entry(builder);
 
     GMenu *menu_root = G_MENU(gtk_builder_get_object(builder, "fsearch_listview_popup_menu"));
+
+    FsearchConfig *config = fsearch_application_get_config(FSEARCH_APPLICATION_DEFAULT);
+    if (config->diff_tool_cmd && *config->diff_tool_cmd) {
+        g_autoptr(GMenu) compare_section = g_menu_new();
+        g_autoptr(GMenuItem) compare_item = g_menu_item_new(_("_Compare"), "win.compare-files");
+        g_autoptr(GIcon) icon = g_themed_icon_new("view-dual");
+        g_menu_item_set_icon(compare_item, icon);
+        g_menu_append_item(compare_section, compare_item);
+        g_menu_insert_section(menu_root, 1, NULL, G_MENU_MODEL(compare_section));
+    }
+
     GtkWidget *menu_widget = gtk_menu_new_from_model(G_MENU_MODEL(menu_root));
 
     gtk_menu_attach_to_widget(GTK_MENU(menu_widget), GTK_WIDGET(widget), NULL);

--- a/src/fsearch_preferences.ui
+++ b/src/fsearch_preferences.ui
@@ -214,6 +214,44 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkBox" id="diff_tool_box">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="has-tooltip">True</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Diff tool command:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkEntry" id="diff_tool_entry">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="placeholder-text" translatable="yes">e.g. meld</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">5</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFrame" id="action_after_file_open_frame">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -612,6 +650,22 @@
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
                                     <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="show_dialog_failed_diff">
+                                    <property name="label" translatable="yes">diff tool failed to start</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="has-tooltip">True</property>
+                                    <property name="margin-start">24</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">2</property>
                                   </packing>
                                 </child>
                               </object>
@@ -1508,6 +1562,30 @@ You can configure if those actions should be triggered when the file was opened 
                     <property name="name">page4</property>
                     <property name="title">page4</property>
                     <property name="position">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="help_diff_tool">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">&lt;b&gt;Diff tool command:&lt;/b&gt;
+
+Specifies the external application to use for comparing file contents. When a command is entered here, a 'Compare' action will become available in the right-click context menu when exactly two files are selected.
+
+FSearch executes this command and appends the two selected file paths as arguments. For example, if you enter &lt;i&gt;meld&lt;/i&gt;, the final command will look like this:
+&lt;i&gt;meld "/path/to/file1" "/path/to/file2"&lt;/i&gt;
+
+Popular comparison tools include: &lt;i&gt;meld, kdiff3, diffuse, code --diff&lt;/i&gt;
+
+The specified tool must be installed and available in your system's PATH.</property>
+                    <property name="use-markup">True</property>
+                    <property name="wrap">True</property>
+                    <property name="selectable">True</property>
+                  </object>
+                  <packing>
+                    <property name="name">page36</property>
+                    <property name="title">page36</property>
+                    <property name="position">36</property>
                   </packing>
                 </child>
                 <child>

--- a/src/fsearch_preferences_ui.c
+++ b/src/fsearch_preferences_ui.c
@@ -59,6 +59,8 @@ typedef struct {
     GtkToggleButton *action_after_file_open_keyboard;
     GtkToggleButton *action_after_file_open_mouse;
     GtkToggleButton *show_indexing_status;
+    GtkBox *diff_tool_box;
+    GtkEntry *diff_tool_entry;
 
     // Search page
     GtkToggleButton *auto_search_in_path_button;
@@ -84,6 +86,7 @@ typedef struct {
 
     // Dialog page
     GtkToggleButton *show_dialog_failed_opening;
+    GtkToggleButton *show_dialog_failed_diff;
 
     // Include page
     GtkTreeView *index_list;
@@ -497,6 +500,7 @@ preferences_ui_get_state(FsearchPreferencesInterface *ui) {
     new_config->show_indexing_status = gtk_toggle_button_get_active(ui->show_indexing_status);
     // Dialogs
     new_config->show_dialog_failed_opening = gtk_toggle_button_get_active(ui->show_dialog_failed_opening);
+    new_config->show_dialog_failed_diff = gtk_toggle_button_get_active(ui->show_dialog_failed_diff);
     new_config->auto_search_in_path = gtk_toggle_button_get_active(ui->auto_search_in_path_button);
     new_config->auto_match_case = gtk_toggle_button_get_active(ui->auto_match_case_button);
     new_config->hide_results_on_empty_search = gtk_toggle_button_get_active(ui->hide_results_button);
@@ -505,6 +509,14 @@ preferences_ui_get_state(FsearchPreferencesInterface *ui) {
     new_config->launch_desktop_files = gtk_toggle_button_get_active(ui->launch_desktop_files_button);
     new_config->show_listview_icons = gtk_toggle_button_get_active(ui->show_icons_button);
     new_config->exclude_hidden_items = gtk_toggle_button_get_active(ui->exclude_hidden_items_button);
+
+    g_clear_pointer(&new_config->diff_tool_cmd, g_free);
+    const char *cmd = gtk_entry_get_text(ui->diff_tool_entry);
+    if (cmd && *cmd) {
+        new_config->diff_tool_cmd = g_strdup(cmd);
+    } else {
+        new_config->diff_tool_cmd = NULL;
+    }
 
     g_clear_pointer(&new_config->exclude_files, g_strfreev);
     new_config->exclude_files = g_strsplit(gtk_entry_get_text(ui->exclude_files_entry), ";", -1);
@@ -658,6 +670,14 @@ preferences_ui_init(FsearchPreferencesInterface *ui, FsearchPreferencesPage page
                                                  "help_show_indexing_status",
                                                  new_config->show_indexing_status);
 
+    ui->diff_tool_box = GTK_BOX(gtk_builder_get_object(ui->builder, "diff_tool_box"));
+    builder_init_widget(ui->builder, "diff_tool_box", "help_diff_tool");
+    ui->diff_tool_entry = GTK_ENTRY(gtk_builder_get_object(ui->builder, "diff_tool_entry"));
+
+    if (new_config->diff_tool_cmd) {
+        gtk_entry_set_text(ui->diff_tool_entry, new_config->diff_tool_cmd);
+    }
+
     // Search page
     ui->auto_search_in_path_button =
         toggle_button_get(ui->builder, "auto_search_in_path_button", "help_auto_path", new_config->auto_search_in_path);
@@ -736,6 +756,10 @@ preferences_ui_init(FsearchPreferencesInterface *ui, FsearchPreferencesPage page
                                                        "show_dialog_failed_opening",
                                                        "help_warn_failed_open",
                                                        new_config->show_dialog_failed_opening);
+    ui->show_dialog_failed_diff = toggle_button_get(ui->builder,
+                                                    "show_dialog_failed_diff",
+                                                    "help_warn_failed_open",
+                                                    new_config->show_dialog_failed_diff);
 
     // Include page
     ui->index_list = GTK_TREE_VIEW(builder_init_widget(ui->builder, "index_list", "help_index_list"));

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -3,6 +3,7 @@ test_query = executable('test_query', 'test_query.c', dependencies: libfsearch_d
 test_size_utils = executable('test_size_utils', 'test_size_utils.c', dependencies: libfsearch_dep)
 test_string_utils = executable('test_string_utils', 'test_string_utils.c', dependencies: libfsearch_dep)
 test_time_utils = executable('test_time_utils', 'test_time_utils.c', dependencies: libfsearch_dep)
+test_config = executable('test_config', 'test_config.c', dependencies: libfsearch_dep)
 
 test('test_array',
      test_array,
@@ -34,6 +35,13 @@ test('test_string_utils',
 )
 test('test_time_utils',
      test_time_utils,
+     env: [
+       'G_TEST_SRCDIR=@0@'.format(meson.current_source_dir()),
+       'G_TEST_BUILDDIR=@0@'.format(meson.current_build_dir()),
+     ],
+)
+test('test_config',
+     test_config,
      env: [
        'G_TEST_SRCDIR=@0@'.format(meson.current_source_dir()),
        'G_TEST_BUILDDIR=@0@'.format(meson.current_build_dir()),

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -1,0 +1,72 @@
+#include <glib.h>
+
+#include "fsearch_config.h"
+
+// define how to free a FsearchConfig pointer
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FsearchConfig, config_free)
+
+static void
+test_config_cmp_non_destructive_changes(void) {
+    // Setup: Create a default config (c1) and a perfect copy (c2)
+    g_autoptr(FsearchConfig) c1 = g_new0(FsearchConfig, 1);
+    config_load_default(c1);
+    g_autoptr(FsearchConfig) c2 = config_copy(c1);
+
+    // Test 1: Two identical configs should report no changes.
+    // This is a sanity check to ensure our baseline is correct.
+    FsearchConfigCompareResult result = config_cmp(c1, c2);
+    g_assert_false(result.database_config_changed);
+    g_assert_false(result.listview_config_changed);
+    g_assert_false(result.search_config_changed);
+    g_clear_pointer(&c2, config_free);
+
+    // Test 2: Changing only the diff_tool_cmd should trigger a listview_config_changed,
+    // and MUST NOT trigger a database_config_changed. This is the core test for the feature.
+    c2 = config_copy(c1);
+    g_free(c2->diff_tool_cmd);
+    c2->diff_tool_cmd = g_strdup("meld");
+
+    result = config_cmp(c1, c2);
+    g_assert_false(result.database_config_changed);
+    g_assert_true(result.listview_config_changed);
+    g_assert_false(result.search_config_changed);
+    g_clear_pointer(&c2, config_free);
+
+    // Test 3: Changing only the folder_open_cmd should also trigger a listview_config_changed.
+    c2 = config_copy(c1);
+    g_free(c2->folder_open_cmd);
+    c2->folder_open_cmd = g_strdup("thunar");
+
+    result = config_cmp(c1, c2);
+    g_assert_false(result.database_config_changed);
+    g_assert_true(result.listview_config_changed);
+    g_assert_false(result.search_config_changed);
+    g_clear_pointer(&c2, config_free);
+}
+
+static void
+test_config_cmp_destructive_change(void) {
+    g_autoptr(FsearchConfig) c1 = g_new0(FsearchConfig, 1);
+    config_load_default(c1);
+    g_autoptr(FsearchConfig) c2 = config_copy(c1);
+
+    // Test: Changing a database-related setting like 'exclude_hidden_items'
+    // MUST trigger a database_config_changed. This is a control test to
+    // prove that our logic correctly distinguishes between change types.
+    c2->exclude_hidden_items = !c1->exclude_hidden_items;
+
+    FsearchConfigCompareResult result = config_cmp(c1, c2);
+    g_assert_true(result.database_config_changed);
+    g_assert_false(result.listview_config_changed);
+    g_assert_false(result.search_config_changed);
+}
+
+int
+main(int argc, char *argv[]) {
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/FSearch/config/cmp_non_destructive", test_config_cmp_non_destructive_changes);
+    g_test_add_func("/FSearch/config/cmp_destructive", test_config_cmp_destructive_change);
+
+    return g_test_run();
+}


### PR DESCRIPTION
This adds a "Compare" action to the right-click context menu. This action is dynamically added to the menu only when a diff tool command is configured in Preferences. It is enabled when exactly two files are selected.

Motivation:
So, I had a flow in windows where i used Everything to search for a file, selected two files with the same name but different directories, right-click - and used WinMerge to see the differences between them.

I use linux mint now so fsearch is the closest thing to Everything, and the only missing part was comparing (I use meld), which this commit adds.

---

More info:

The feature includes:
- A new "Diff tool command" text entry in Preferences -> Interface. The placeholder text is shown by default.
- A new action `win.compare-files` that launches the configured command with the two selected file paths.
- A warning dialog if the command fails to execute.
- The action state is updated immediately after changing the setting without losing the user's current file selection.

This also includes a small fix to `config_cmp` to correctly classify external tool commands (`diff_tool_cmd` and the existing `folder_open_cmd`) as non-destructive UI changes, preventing an unnecessary and disruptive database reload when these settings are modified. A unit test has been added to verify this specific logic.


<img width="727" height="448" alt="compare" src="https://github.com/user-attachments/assets/4e36da1e-4402-497a-aa2f-6c22ba47f580" />

<img width="636" height="855" alt="compare-settings" src="https://github.com/user-attachments/assets/11ad0f77-9a29-4989-9666-13c5f5031911" />

