### PR TITLE
Drag & drop support

### DIFF
--- a/src/fsearch_list_view.c
+++ b/src/fsearch_list_view.c
@@ -8,6 +8,7 @@
 #define TEXT_HEIGHT_FALLBACK 20
 #define ROW_HEIGHT_DEFAULT 30
 #define COLUMN_RESIZE_AREA_WIDTH 6
+#define DEFAULT_MAX_ROWS_IN_VIEWPORT 200
 
 typedef enum {
     RUBBERBAND_SELECT_INACTIVE,
@@ -99,6 +100,12 @@ struct _FsearchListView {
 
     gboolean drag_and_drop_started;
     gboolean single_row_selected;
+
+    // An array of end_x_position for each row. For unselected rows:
+    // Starting a mouse drag inside the range of 0 to "end x position" will start a drag & drop operation
+    // Starting a mouse drag outside that rage will start a rubberband selection
+    gint *row_drag_end_position_array;
+    guint row_drag_end_position_array_size;
 };
 
 enum {
@@ -784,12 +791,29 @@ on_fsearch_list_view_multi_press_gesture_pressed(GtkGestureMultiPress *gesture,
                 fsearch_list_view_selection_toggle_silent(view, row_idx);
             }
             else {
-                // Dragging only starts when clicking in a valid column, otherwise - it's a rubberband selection event
-                FsearchListViewColumn *col = fsearch_list_view_get_col_for_x_view(view, x);
-                if(col) {
-                    view->drag_and_drop_started = fsearch_list_view_is_selected(view, row_idx);
-                    if(view->drag_and_drop_started) {
-                        return;
+                gboolean is_selected = fsearch_list_view_is_selected(view, row_idx);
+
+                if(!is_selected) {
+                    fsearch_list_view_selection_clear_silent(view);
+                    fsearch_list_view_selection_toggle_silent(view, row_idx);
+                    if (view->single_click_activate) {
+                        FsearchListViewColumn *col = fsearch_list_view_get_col_for_x_view(view, x);
+                        if (col) {
+                            g_signal_emit(view,
+                                        signals[FSEARCH_LIST_VIEW_SIGNAL_ROW_ACTIVATED],
+                                        0,
+                                        col->type,
+                                        get_row_idx_for_sort_type(view, row_idx));
+                        }
+                    }
+                }
+
+                if (!view->single_click_activate) {
+                    FsearchListViewColumn *col = fsearch_list_view_get_col_for_x_view(view, x);
+                    if(col) {
+                        // Dragging only starts when clicking in the range of 0 to "drag end x position". otherwise - it's a rubberband selection operation
+                        gint drag_end_x = view->row_drag_end_position_array[row_idx % view->row_drag_end_position_array_size];
+                        view->drag_and_drop_started = (x < drag_end_x) || is_selected;
                     }
                 }
             }
@@ -870,6 +894,9 @@ on_fsearch_list_view_multi_press_gesture_released(GtkGestureMultiPress *gesture,
                             get_row_idx_for_sort_type(view, row_idx));
         }
     }
+
+    fsearch_list_view_selection_changed(view);
+    gtk_widget_queue_draw(GTK_WIDGET(view));
 }
 
 static void
@@ -1895,6 +1922,12 @@ fsearch_list_view_destroy(GtkWidget *widget) {
     GTK_WIDGET_CLASS(fsearch_list_view_parent_class)->destroy(widget);
 }
 
+static void fsearch_list_view_finalize(GObject *obj) {
+    FsearchListView *view = FSEARCH_LIST_VIEW(obj);
+
+    g_free(view->row_drag_end_position_array);
+}
+
 static void
 fsearch_list_view_class_init(FsearchListViewClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
@@ -1903,6 +1936,7 @@ fsearch_list_view_class_init(FsearchListViewClass *klass) {
 
     object_class->set_property = fsearch_list_view_set_property;
     object_class->get_property = fsearch_list_view_get_property;
+    object_class->finalize = fsearch_list_view_finalize;
 
     g_object_class_override_property(object_class, PROP_HADJUSTMENT, "hadjustment");
     g_object_class_override_property(object_class, PROP_VADJUSTMENT, "vadjustment");
@@ -2023,6 +2057,10 @@ fsearch_list_view_init(FsearchListView *view) {
     gtk_style_context_add_class(style, GTK_STYLE_CLASS_VIEW);
     gtk_style_context_add_class(style, GTK_STYLE_CLASS_LINKED);
     // gtk_style_context_add_class(style, GTK_STYLE_CLASS_CELL);
+
+    view->row_drag_end_position_array_size = DEFAULT_MAX_ROWS_IN_VIEWPORT;
+    view->row_drag_end_position_array = g_new(gint, view->row_drag_end_position_array_size);
+
 }
 
 FsearchListView *
@@ -2379,6 +2417,18 @@ fsearch_list_view_set_single_click_activate(FsearchListView *view, gboolean valu
     }
     view->single_click_activate = value;
 }
+
+void
+fsearch_list_view_set_row_drag_end_position(FsearchListView *view, int32_t row, gint end_x) {
+    gint num_rows_in_view = fsearch_list_view_num_rows_for_view_height(view) * 2;
+    guint length = view->row_drag_end_position_array_size;
+    if(num_rows_in_view > length) {
+        view->row_drag_end_position_array_size = num_rows_in_view;
+        view->row_drag_end_position_array = g_realloc(view->row_drag_end_position_array, view->row_drag_end_position_array_size * sizeof(gint));
+    }
+    view->row_drag_end_position_array[row % length] = end_x;
+}
+
 
 FsearchListViewColumn *
 fsearch_list_view_column_ref(FsearchListViewColumn *col) {

--- a/src/fsearch_list_view.c
+++ b/src/fsearch_list_view.c
@@ -96,6 +96,9 @@ struct _FsearchListView {
     FsearchListViewUnselectAllFunc unselect_func;
     FsearchListViewNumSelectedFunc num_selected_func;
     gpointer selection_user_data;
+
+    gboolean drag_and_drop_started;
+    gboolean single_row_selected;
 };
 
 enum {
@@ -104,7 +107,7 @@ enum {
     UNSET_ROW = -3,
 };
 
-enum { FSEARCH_LIST_VIEW_SIGNAL_ROW_ACTIVATED, FSEARCH_LIST_VIEW_SIGNAL_POPUP, NUM_FSEARCH_LIST_VIEW_SIGNALS };
+enum { FSEARCH_LIST_VIEW_SIGNAL_ROW_ACTIVATED, FSEARCH_LIST_VIEW_SIGNAL_POPUP, FSEARCH_LIST_VIEW_SIGNAL_DRAG, NUM_FSEARCH_LIST_VIEW_SIGNALS };
 
 static guint signals[NUM_FSEARCH_LIST_VIEW_SIGNALS];
 
@@ -781,22 +784,16 @@ on_fsearch_list_view_multi_press_gesture_pressed(GtkGestureMultiPress *gesture,
                 fsearch_list_view_selection_toggle_silent(view, row_idx);
             }
             else {
-                view->cursor_idx = row_idx;
-                fsearch_list_view_selection_clear_silent(view);
-                fsearch_list_view_selection_toggle_silent(view, row_idx);
-                if (view->single_click_activate) {
-                    FsearchListViewColumn *col = fsearch_list_view_get_col_for_x_view(view, x);
-                    if (col) {
-                        g_signal_emit(view,
-                                      signals[FSEARCH_LIST_VIEW_SIGNAL_ROW_ACTIVATED],
-                                      0,
-                                      col->type,
-                                      get_row_idx_for_sort_type(view, row_idx));
+                // Dragging only starts when clicking in a valid column, otherwise - it's a rubberband selection event
+                FsearchListViewColumn *col = fsearch_list_view_get_col_for_x_view(view, x);
+                if(col) {
+                    view->drag_and_drop_started = fsearch_list_view_is_selected(view, row_idx);
+                    if(view->drag_and_drop_started) {
+                        return;
                     }
                 }
             }
             fsearch_list_view_selection_changed(view);
-            fsearch_list_view_scroll_row_into_view(view, view->cursor_idx);
         }
 
         if (n_press == 2 && !view->single_click_activate) {
@@ -838,13 +835,40 @@ on_fsearch_list_view_multi_press_gesture_released(GtkGestureMultiPress *gesture,
                                                   FsearchListView *view) {
     guint button_pressed = gtk_gesture_single_get_current_button(GTK_GESTURE_SINGLE(gesture));
 
+    view->drag_and_drop_started = FALSE;
+
     if (button_pressed > 3) {
         return;
     }
 
-    int row_idx = fsearch_list_view_get_row_idx_for_y_view(view, y);
-    if (row_idx < 0) {
+    // Selection of a single row is done on mouse release so we can identify single row selection vs start of drag and drop operation
+    // If the release is done after selection extention or modification, or as part of
+    // a rubberband selection, we don't reset the selection to a single row.
+
+    if(!view->single_row_selected)
         return;
+
+    gboolean modify_selection;
+    gboolean extend_selection;
+
+    fsearch_list_view_get_selection_modifiers(view, &modify_selection, &extend_selection);
+
+    if(modify_selection || extend_selection)
+        return;
+
+    gint row_idx = fsearch_list_view_get_row_idx_for_y_view(view, y);
+    view->cursor_idx = row_idx;
+    fsearch_list_view_selection_clear_silent(view);
+    fsearch_list_view_selection_toggle_silent(view, row_idx);
+    if (view->single_click_activate) {
+        FsearchListViewColumn *col = fsearch_list_view_get_col_for_x_view(view, x);
+        if (col) {
+            g_signal_emit(view,
+                            signals[FSEARCH_LIST_VIEW_SIGNAL_ROW_ACTIVATED],
+                            0,
+                            col->type,
+                            get_row_idx_for_sort_type(view, row_idx));
+        }
     }
 }
 
@@ -854,6 +878,9 @@ on_fsearch_list_view_bin_drag_gesture_end(GtkGestureDrag *gesture,
                                           gdouble offset_y,
                                           FsearchListView *view) {
     //  GdkEventSequence *sequence = gtk_gesture_single_get_current_sequence(GTK_GESTURE_SINGLE(gesture));
+
+    view->single_row_selected  = view->rubberband_start_idx == view->rubberband_end_idx;
+
     if (view->bin_drag_mode) {
         view->bin_drag_mode = FALSE;
         view->rubberband_state = RUBBERBAND_SELECT_INACTIVE;
@@ -865,6 +892,7 @@ on_fsearch_list_view_bin_drag_gesture_end(GtkGestureDrag *gesture,
         view->rubberband_end_idx = UNSET_ROW;
         view->rubberband_extend = FALSE;
         view->rubberband_modify = FALSE;
+        view->drag_and_drop_started = FALSE;
         gtk_widget_queue_draw(GTK_WIDGET(view));
     }
 }
@@ -1073,6 +1101,13 @@ on_fsearch_list_view_bin_drag_gesture_update(GtkGestureDrag *gesture,
     // if (gtk_gesture_get_sequence_state(GTK_GESTURE(gesture), sequence) != GTK_EVENT_SEQUENCE_CLAIMED) {
     //     return;
     // }
+
+    if(view->drag_and_drop_started)
+    {
+        view->drag_and_drop_started = FALSE;
+        g_signal_emit(view, signals[FSEARCH_LIST_VIEW_SIGNAL_DRAG], 0);
+        return;
+    }
 
     if (view->bin_drag_mode == FALSE) {
         return;
@@ -1906,6 +1941,17 @@ fsearch_list_view_class_init(FsearchListViewClass *klass) {
                                                                    2,
                                                                    G_TYPE_INT,
                                                                    G_TYPE_INT);
+
+    signals[FSEARCH_LIST_VIEW_SIGNAL_DRAG] =
+        g_signal_new("on-drag",
+               G_TYPE_FROM_CLASS(klass),
+               G_SIGNAL_RUN_LAST,
+               0,
+               NULL,
+               NULL,
+               NULL,
+               G_TYPE_NONE,
+               0);
 
 #if GTK_CHECK_VERSION(3, 20, 0)
     gtk_widget_class_set_css_name(widget_class, "treeview");

--- a/src/fsearch_list_view.h
+++ b/src/fsearch_list_view.h
@@ -155,3 +155,6 @@ fsearch_list_view_set_draw_row_func(FsearchListView *view, FsearchListViewDrawRo
 
 gboolean
 fsearch_list_view_redraw_row(FsearchListView *view, int row_idx);
+
+void
+fsearch_list_view_set_row_drag_end_position(FsearchListView *view, int32_t row, gint end_x);

--- a/src/fsearch_result_view.c
+++ b/src/fsearch_result_view.c
@@ -384,6 +384,13 @@ fsearch_result_view_draw_row(FsearchResultView *result_view,
         pango_layout_set_ellipsize(layout, column->ellipsize_mode);
         gtk_render_layout(context, cr, x + ROW_PADDING_X + dx, rect->y + ROW_PADDING_Y, layout);
         x += column->effective_width;
+
+        // Setting the row drag end position so that starting a mouse drag from within the filename (+icon) bounding box will start a drag and drop operation
+        if(column->type == DATABASE_INDEX_TYPE_NAME) {
+            int width;
+            pango_layout_get_pixel_size(layout, &width, NULL);
+            fsearch_list_view_set_row_drag_end_position(result_view->list_view, row, width + ROW_PADDING_X + dw);
+        }
         cairo_restore(cr);
     }
     gtk_style_context_restore(context);

--- a/src/fsearch_result_view.c
+++ b/src/fsearch_result_view.c
@@ -381,14 +381,14 @@ fsearch_result_view_draw_row(FsearchResultView *result_view,
 
         pango_layout_set_width(layout, (column->effective_width - 2 * ROW_PADDING_X - dw) * PANGO_SCALE);
         pango_layout_set_alignment(layout, column->alignment);
-        pango_layout_set_ellipsize(layout, column->ellipsize_mode);
+        pango_layout_set_ellipsize(layout, column->ellipsize_mode);        
         gtk_render_layout(context, cr, x + ROW_PADDING_X + dx, rect->y + ROW_PADDING_Y, layout);
         x += column->effective_width;
 
         // Setting the row drag end position so that starting a mouse drag from within the filename (+icon) bounding box will start a drag and drop operation
-        if(column->type == DATABASE_INDEX_TYPE_NAME) {
+        if(column->type == DATABASE_INDEX_PROPERTY_NAME) {
             int width;
-            pango_layout_get_pixel_size(layout, &width, NULL);
+            pango_layout_get_pixel_size(layout, &width, NULL);            
             fsearch_list_view_set_row_drag_end_position(result_view->list_view, row, width + ROW_PADDING_X + dw);
         }
         cairo_restore(cr);

--- a/src/fsearch_window.c
+++ b/src/fsearch_window.c
@@ -793,7 +793,7 @@ static void
 on_drag(FsearchListView *lv, int row, gpointer user_data) {
     GtkTargetEntry targets[] = {{"text/uri-list", 0, 0}};
     GtkTargetList *target_list = gtk_target_list_new(targets, 1);
-    gtk_drag_begin_with_coordinates(GTK_WIDGET(lv), target_list, GDK_ACTION_LINK, 1, NULL, -1, -1);
+    gtk_drag_begin_with_coordinates(GTK_WIDGET(lv), target_list, GDK_ACTION_COPY, 1, NULL, -1, -1);
 }
 
 static void

--- a/src/fsearch_window.c
+++ b/src/fsearch_window.c
@@ -762,10 +762,9 @@ on_listview_row_is_selected(int row, gpointer user_data) {
 }
 
 static void
-append_path_to_uri_list(gpointer key, gpointer value, gpointer userdata) {
-    FsearchDatabaseEntry *e = (FsearchDatabaseEntry *)value;
+append_path_to_uri_list(FsearchDatabaseEntry *entry, gpointer userdata) {    
     GString *uri_list = (GString *)userdata;
-    g_autoptr(GString) path = db_entry_get_path_full(e);
+    g_autoptr(GString) path = db_entry_get_path_full(entry);
     gchar *uri = g_filename_to_uri(path->str, NULL, NULL);
     g_string_append(uri_list, uri);
     g_string_append(uri_list, "\r\n");
@@ -774,11 +773,10 @@ append_path_to_uri_list(gpointer key, gpointer value, gpointer userdata) {
 
 static void
 on_drag_data_get(GtkWidget *widget, GdkDragContext *context, GtkSelectionData *selection_data, guint info, guint time, gpointer user_data) {
-    FsearchApplicationWindow *win = FSEARCH_APPLICATION_WINDOW(user_data);
-    FsearchDatabaseView *view = win->result_view->database_view;
+    FsearchApplicationWindow *win = FSEARCH_APPLICATION_WINDOW(user_data);    
 
     GString *uri_list = g_string_new(NULL);
-    db_view_selection_for_each(view, append_path_to_uri_list, uri_list);
+    fsearch_application_window_selection_for_each(win, append_path_to_uri_list, uri_list);
 
     gtk_selection_data_set(selection_data,
                            gdk_atom_intern("text/uri-list", TRUE),

--- a/src/fsearch_window.c
+++ b/src/fsearch_window.c
@@ -762,6 +762,41 @@ on_listview_row_is_selected(int row, gpointer user_data) {
 }
 
 static void
+append_path_to_uri_list(gpointer key, gpointer value, gpointer userdata) {
+    FsearchDatabaseEntry *e = (FsearchDatabaseEntry *)value;
+    GString *uri_list = (GString *)userdata;
+    g_autoptr(GString) path = db_entry_get_path_full(e);
+    gchar *uri = g_filename_to_uri(path->str, NULL, NULL);
+    g_string_append(uri_list, uri);
+    g_string_append(uri_list, "\r\n");
+    g_free(uri);
+}
+
+static void
+on_drag_data_get(GtkWidget *widget, GdkDragContext *context, GtkSelectionData *selection_data, guint info, guint time, gpointer user_data) {
+    FsearchApplicationWindow *win = FSEARCH_APPLICATION_WINDOW(user_data);
+    FsearchDatabaseView *view = win->result_view->database_view;
+
+    GString *uri_list = g_string_new(NULL);
+    db_view_selection_for_each(view, append_path_to_uri_list, uri_list);
+
+    gtk_selection_data_set(selection_data,
+                           gdk_atom_intern("text/uri-list", TRUE),
+                           8,
+                           (const guchar *)uri_list->str,
+                           uri_list->len);
+
+    g_string_free(uri_list, TRUE);
+}
+
+static void
+on_drag(FsearchListView *lv, int row, gpointer user_data) {
+    GtkTargetEntry targets[] = {{"text/uri-list", 0, 0}};
+    GtkTargetList *target_list = gtk_target_list_new(targets, 1);
+    gtk_drag_begin_with_coordinates(GTK_WIDGET(lv), target_list, GDK_ACTION_LINK, 1, NULL, -1, -1);
+}
+
+static void
 fsearch_application_window_init_overlays(FsearchApplicationWindow *win) {
     g_assert(FSEARCH_IS_APPLICATION_WINDOW(win));
 
@@ -833,6 +868,8 @@ fsearch_application_window_init_listview(FsearchApplicationWindow *win) {
                             win,
                             G_CONNECT_AFTER);
     g_signal_connect(list_view, "key-press-event", G_CALLBACK(on_listview_key_press_event), win);
+    g_signal_connect(list_view, "on-drag", G_CALLBACK(on_drag), win);
+    g_signal_connect(list_view, "drag-data-get", G_CALLBACK(on_drag_data_get), win);
 
     win->result_view->list_view = list_view;
 }


### PR DESCRIPTION
This PR adds support for drag & drop.
The mechanics mimic those of a file manager (KDE Dolphin, for example):
- A drag & drop operation is started when left clicking on an already selected row and dragging the mouse
- Starting a mouse drag from a row that is not selected:
    - If the mouse drag starts when clicking on the filename - a drag & drop operation will start.
    - Otherwise, it's a rubberband select operation
- Single clicking on a row will reset the selection to that row only on mouse release - so we'll be able to differentiate between single row selections and the beginning  of a drag & drop event.

Additional fixes provided by AccessWebBE: https://github.com/cboxdoerfer/fsearch/pull/640#issuecomment-5638886737