### PR TITLE
align RTL text to the left when widget dir is not RTL

### DIFF
--- a/src/fsearch_result_view.c
+++ b/src/fsearch_result_view.c
@@ -462,6 +462,11 @@ fsearch_result_view_draw_row(FsearchResultView *result_view,
             set_attributes(layout, ctx->match_data, column->type);
         }
 
+        if(!right_to_left_text) {
+            pango_layout_set_alignment(layout, PANGO_ALIGN_LEFT);
+            pango_layout_set_auto_dir(layout, FALSE);
+        }
+
         pango_layout_set_text(layout, text ? text : _("Invalid row data"), text_len);
 
         pango_layout_set_width(layout, (column->effective_width - 2 * ROW_PADDING_X - dw) * PANGO_SCALE);


### PR DESCRIPTION
This PR aligns RTL text to the left, when the widget's direction is not RTL.
This is more in line with the style of other file managers:

Current FSearch state:
<img width="573" height="245" alt="image" src="https://github.com/user-attachments/assets/2e2e0f60-24b1-4f6a-8ac9-380e922f4856" />

KDE Dolphin:
<img width="1017" height="270" alt="image" src="https://github.com/user-attachments/assets/cd96dfbc-4c18-4357-b90b-0e3c368999e1" />

Windows Explorer:
<img width="1017" height="270" alt="image" src="https://github.com/user-attachments/assets/550c49ca-4a18-4567-a14f-ec928d260d40" />


Everything:
<img width="798" height="245" alt="image" src="https://github.com/user-attachments/assets/b913a228-d675-44a6-9cda-bd2c6c5d1efd" />
