### PR TITLE
Add Docker build support for isolated builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# Dockerfile for building FSearch in isolation
+# This ensures the build happens in a clean, sandboxed environment
+
+FROM ubuntu:24.04
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install all required build dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    build-essential \
+    meson \
+    itstool \
+    libtool \
+    pkg-config \
+    intltool \
+    libicu-dev \
+    libpcre2-dev \
+    libglib2.0-dev \
+    libgtk-3-dev \
+    libxml2-utils \
+    appstream \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user for building
+RUN useradd -m -s /bin/bash builder
+
+# Set up the build directory with proper ownership
+WORKDIR /build
+RUN chown -R builder:builder /build
+
+# Copy the source code
+COPY --chown=builder:builder . .
+
+# Switch to non-root user for building
+USER builder
+
+# Configure the build
+RUN meson setup builddir
+
+# Build the project
+RUN ninja -C builddir
+
+# Run tests to verify the build
+RUN ninja -C builddir test
+
+# The built binary will be at: builddir/src/fsearch
+# You can copy it out using: docker cp <container>:/build/builddir/src/fsearch .
+
+CMD ["/bin/bash"]

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Docker build script for FSearch
+# This script builds FSearch in a sandboxed Docker container
+
+set -e  # Exit on error
+
+echo "========================================="
+echo "FSearch Docker Build Script"
+echo "========================================="
+echo ""
+
+# Check if Docker is installed
+if ! command -v docker &> /dev/null; then
+    echo "ERROR: Docker is not installed."
+    echo "Please install Docker first:"
+    echo "  sudo apt install docker.io"
+    echo "  sudo usermod -aG docker $USER"
+    echo "  # Then log out and log back in"
+    exit 1
+fi
+
+# Check if user can run Docker
+if ! docker ps &> /dev/null; then
+    echo "ERROR: Cannot run Docker commands."
+    echo "You may need to:"
+    echo "  1. Start Docker service: sudo systemctl start docker"
+    echo "  2. Add yourself to docker group: sudo usermod -aG docker $USER"
+    echo "  3. Log out and log back in"
+    exit 1
+fi
+
+echo "Step 1: Building Docker image..."
+docker build -t fsearch-builder:latest .
+
+echo ""
+echo "Step 2: Running build in container..."
+docker run --name fsearch-build-temp fsearch-builder:latest
+
+echo ""
+echo "Step 3: Extracting built binary..."
+docker cp fsearch-build-temp:/build/builddir/src/fsearch ./fsearch-binary
+
+echo ""
+echo "Step 4: Cleaning up container..."
+docker rm fsearch-build-temp
+
+echo ""
+echo "========================================="
+echo "Build completed successfully!"
+echo "========================================="
+echo ""
+echo "The built binary is available at: ./fsearch-binary"
+echo ""
+echo "To inspect the build environment:"
+echo "  docker run -it --rm fsearch-builder:latest /bin/bash"
+echo ""
+echo "To extract other files from the build:"
+echo "  docker run --name temp fsearch-builder:latest"
+echo "  docker cp temp:/build/builddir/src/fsearch ."
+echo "  docker rm temp"
+echo ""
+echo "To remove the Docker image:"
+echo "  docker rmi fsearch-builder:latest"
+echo ""

--- a/docs/DOCKER_BUILD.md
+++ b/docs/DOCKER_BUILD.md
@@ -1,0 +1,163 @@
+# Building FSearch with Docker
+
+This guide explains how to build FSearch in an isolated Docker container, which is useful for:
+- Building without installing system dependencies
+- Testing builds in a clean environment
+- Creating reproducible builds
+- Security-conscious users who want to isolate untrusted code compilation
+
+## Quick Start
+
+```bash
+# Build the Docker image and compile FSearch
+docker build -t fsearch-builder .
+
+# Extract the binary
+docker run --name fsearch-build fsearch-builder
+docker cp fsearch-build:/build/builddir/src/fsearch ./fsearch
+docker rm fsearch-build
+```
+
+## Prerequisites
+
+- Docker installed and running
+- User added to docker group (or use sudo)
+
+### Installing Docker
+
+**Ubuntu/Debian:**
+```bash
+sudo apt update
+sudo apt install docker.io
+sudo systemctl start docker
+sudo usermod -aG docker $USER
+# Log out and log back in for group changes to take effect
+```
+
+**Fedora:**
+```bash
+sudo dnf install docker
+sudo systemctl start docker
+sudo usermod -aG docker $USER
+```
+
+## Building
+
+### Option 1: Automated Script
+
+Use the provided build script:
+```bash
+./docker-build.sh
+```
+
+This will:
+1. Build the Docker image
+2. Compile FSearch in the container
+3. Run tests
+4. Extract the binary to `./fsearch-binary`
+5. Clean up temporary containers
+
+### Option 2: Manual Steps
+
+```bash
+# 1. Build the Docker image
+docker build -t fsearch-builder:latest .
+
+# 2. Run the build
+docker run --name fsearch-build fsearch-builder:latest
+
+# 3. Extract the compiled binary
+docker cp fsearch-build:/build/builddir/src/fsearch ./fsearch-binary
+
+# 4. (Optional) Extract the entire build directory
+docker cp fsearch-build:/build/builddir ./builddir
+
+# 5. Clean up the container
+docker rm fsearch-build
+```
+
+## Installing the Binary
+
+After extraction:
+
+```bash
+# Install to user directory
+mkdir -p ~/.local/bin
+cp ./fsearch-binary ~/.local/bin/fsearch
+chmod +x ~/.local/bin/fsearch
+
+# Or install system-wide
+sudo install -Dm755 ./fsearch-binary /usr/local/bin/fsearch
+```
+
+## Inspecting the Build Environment
+
+To explore the build environment interactively:
+
+```bash
+docker run -it --rm fsearch-builder:latest /bin/bash
+```
+
+Inside the container:
+```bash
+cd /build/builddir
+ls -la
+./src/fsearch --version
+```
+
+## Cleanup
+
+```bash
+# Remove the Docker image
+docker rmi fsearch-builder:latest
+
+# Remove all unused Docker data
+docker system prune -a
+```
+
+## Customizing the Build
+
+The Dockerfile supports different base distributions. Edit the first line:
+
+```dockerfile
+# For Ubuntu 24.04 (default)
+FROM ubuntu:24.04
+
+# For Ubuntu 22.04
+FROM ubuntu:22.04
+
+# For Debian
+FROM debian:bookworm
+```
+
+## Troubleshooting
+
+### Permission Denied
+
+If you get "permission denied" errors:
+```bash
+sudo usermod -aG docker $USER
+newgrp docker
+```
+
+### Build Fails
+
+Check the build logs:
+```bash
+docker build --progress=plain --no-cache -t fsearch-builder:latest .
+```
+
+### Missing Dependencies
+
+The Dockerfile includes all required dependencies. If you encounter issues, ensure you're using a supported base image (Ubuntu 22.04+ or Debian Bookworm+).
+
+## Security Considerations
+
+- The build runs as a non-root user inside the container
+- The container is isolated from your host system
+- Only the final binary is extracted to your host
+- You can inspect the Dockerfile to verify all build steps
+
+## Contributing
+
+If you improve the Docker build process, please consider contributing back to the project!


### PR DESCRIPTION
- Add Dockerfile with Ubuntu 24.04 base
- Add automated docker-build.sh script
- Add comprehensive Docker build documentation
- Build runs as non-root user for security
- Includes all build dependencies and test execution

This enables users to build FSearch without installing system dependencies, useful for testing and security-conscious builds.