### PR TITLE
Remove unnecessary strerror against %m

### DIFF
--- a/src/fsearch_folder_monitor_fanotify.c
+++ b/src/fsearch_folder_monitor_fanotify.c
@@ -357,7 +357,7 @@ fsearch_folder_monitor_fanotify_watch(FsearchFolderMonitorFanotify *self,
                 continue;
             }
             else if (errno != ENOENT) {
-                g_warning("Could not get file handle for '%s': %m", path, strerror(errno));
+                g_warning("Could not get file handle for '%s': %m", path);
             }
             return false;
         }


### PR DESCRIPTION
`strerror(errno)` is unnecessary if you use `%m` as written in `man printf.3`:

```
       m      (glibc extension; supported by uClibc and musl.)  Print output of strerror(errno) (or strerrorname_np(errno) in the alternate
              form).  No argument is required.
```

rather doing this introduces a build warning:

```
In file included from /usr/include/glib-2.0/glib.h:64,
                 from ../src/fsearch_database_entry.h:3,
                 from ../src/fsearch_folder_monitor_fanotify.h:3,
                 from ../src/fsearch_folder_monitor_fanotify.c:1:
../src/fsearch_folder_monitor_fanotify.c: In function ‘fsearch_folder_monitor_fanotify_watch’:
../src/fsearch_folder_monitor_fanotify.c:360:27: warning: too many arguments for format [-Wformat-extra-args]
  360 |                 g_warning("Could not get file handle for '%s': %m", path, strerror(errno));
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/glib-2.0/glib/gmessages.h:367:32: note: in definition of macro ‘g_warning’
  367 |                                __VA_ARGS__)
      |                                ^~~~~~~~~~~
```
