### PR TITLE
Improve metainfo

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v2

--- a/copr/fsearch_nightly.spec
+++ b/copr/fsearch_nightly.spec
@@ -15,7 +15,7 @@ BuildRequires: ninja-build
 BuildRequires: gcc
 BuildRequires: gtk3-devel
 BuildRequires: glib2-devel
-BuildRequires: libappstream-glib
+BuildRequires: appstream
 BuildRequires: desktop-file-utils
 BuildRequires: itstool
 

--- a/copr/fsearch_release.spec
+++ b/copr/fsearch_release.spec
@@ -15,7 +15,7 @@ BuildRequires: ninja-build
 BuildRequires: gcc
 BuildRequires: gtk3-devel
 BuildRequires: glib2-devel
-BuildRequires: libappstream-glib
+BuildRequires: appstream
 BuildRequires: desktop-file-utils
 
 

--- a/data/io.github.cboxdoerfer.FSearch.metainfo.xml.in
+++ b/data/io.github.cboxdoerfer.FSearch.metainfo.xml.in
@@ -4,7 +4,7 @@
     <id>io.github.cboxdoerfer.FSearch</id>
     <metadata_license>CC-BY-SA-4.0</metadata_license>
     <project_license>GPL-2.0-or-later</project_license>
-    <name>FSearch</name>
+    <name translate="no">FSearch</name>
     <summary>A graphical file search application</summary>
     <description>
         <p>
@@ -70,11 +70,16 @@
     <url type="contribute">https://github.com/cboxdoerfer/fsearch/blob/master/CONTRIBUTING.md</url>
     <url type="contact">https://github.com/cboxdoerfer</url>
     <!-- Translators: please do NOT translate this. -->
-    <developer_name>Christian Boxdörfer</developer_name>
+    <developer id="io.github.cboxdoerfer">
+      <name>Christian Boxdörfer</name>
+    </developer>
     <update_contact>christian.boxdoerfer_at_posteo.de</update_contact>
     <translation type="gettext">fsearch</translation>
-    <!-- Validate with `appstream-util validate io.github.cboxdoerfer.FSearch.metainfo.xml.in`. -->
     <content_rating type="oars-1.1" />
+    <launchable type="desktop-id">io.github.cboxdoerfer.FSearch.desktop</launchable>
+    <custom>
+        <value key="Purism::form_factor">workstation</value>
+    </custom>
     <releases>
         <release date="2026-04-11" version="0.3-beta1">
             <description>
@@ -122,8 +127,4 @@
             </description>
         </release>
     </releases>
-    <launchable type="desktop-id">io.github.cboxdoerfer.FSearch.desktop</launchable>
-    <custom>
-        <value key="Purism::form_factor">workstation</value>
-    </custom>
 </component>

--- a/data/io.github.cboxdoerfer.FSearch.metainfo.xml.in
+++ b/data/io.github.cboxdoerfer.FSearch.metainfo.xml.in
@@ -14,15 +14,15 @@
         <p>
             There are a lot of features which make searching as efficient and powerful
             as possible. Such as:
-            <ul>
-                <li>Ignore case (e.g. searching for "<code>fsearch</code>" will match "FSearch" as well)</li>
-                <li>Regular expressions</li>
-                <li>Wildcard support</li>
-                <li>Filter support (e.g. only search for audio files)</li>
-                <li>Exclude certain files and folders</li>
-                <li>Fast sort by name, path, size, modification time and extension</li>
-            </ul>
         </p>
+        <ul>
+            <li>Ignore case (e.g. searching for "<code>fsearch</code>" will match "FSearch" as well)</li>
+            <li>Regular expressions</li>
+            <li>Wildcard support</li>
+            <li>Filter support (e.g. only search for audio files)</li>
+            <li>Exclude certain files and folders</li>
+            <li>Fast sort by name, path, size, modification time and extension</li>
+        </ul>
         <p>
             <em>Note:</em> Due to Flatpak's sandboxing, FSearch can't find every file on your system.
         </p>

--- a/data/io.github.cboxdoerfer.FSearch.metainfo.xml.in
+++ b/data/io.github.cboxdoerfer.FSearch.metainfo.xml.in
@@ -69,9 +69,8 @@
     <url type="vcs-browser">https://github.com/cboxdoerfer/fsearch</url>
     <url type="contribute">https://github.com/cboxdoerfer/fsearch/blob/master/CONTRIBUTING.md</url>
     <url type="contact">https://github.com/cboxdoerfer</url>
-    <!-- Translators: please do NOT translate this. -->
     <developer id="io.github.cboxdoerfer">
-      <name>Christian Boxdörfer</name>
+      <name translate="no">Christian Boxdörfer</name>
     </developer>
     <update_contact>christian.boxdoerfer_at_posteo.de</update_contact>
     <translation type="gettext">fsearch</translation>

--- a/data/meson.build
+++ b/data/meson.build
@@ -38,12 +38,12 @@ metainfo_file = i18n.merge_file(
   install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
   test(
-    'validate-metainfo', appstream_util,
+    'validate-metainfo', appstreamcli,
     args: [
-      'validate-relax', '--nonet', metainfo_file.full_path()
+      'validate', '--no-net', metainfo_file.full_path()
     ]
   )
 endif


### PR DESCRIPTION
This PR improves metainfo things.

### Changes Summary
- Fix appdata paper cuts
  - Backport of https://github.com/flathub/io.github.cboxdoerfer.FSearch/commit/0a5d89ae82c4e0ce3341fb85f9bf234e3ec8e3a9
- Make sure not to translate author name (instead of writing a comment)
- Fix appstreamcli validate error
  - Fixes the following warning when running appstreamcli validate:
    ```
    E: io.github.cboxdoerfer.FSearch:17: description-para-markup-invalid ul
    ```
- Use appstream instead of appstream-glib
  - appstream-glib is heavy maintenance mode [as written in their README](https://github.com/hughsie/appstream-glib) and has not been updated about 2 years
- build_test: Use ubuntu-24.04 runner
  - Because appstreamcli validate failed in CI with the following errors due to an older version of appstream
    ```
    W: io.github.cboxdoerfer.FSearch:370: url-invalid-type vcs-browser
    I: io.github.cboxdoerfer.FSearch:373: unknown-tag developer
    W: io.github.cboxdoerfer.FSearch:371: url-invalid-type contribute
    ```

### Checklist
- [x] Confirmed `meson setup builddir --prefix=/usr && ninja -C builddir test` succeeds
  ```
  1/9 Validate desktop file        OK              0.01s
  2/9 test_database_include        OK              0.00s
  3/9 test_database_exclude        OK              0.01s
  4/9 validate-metainfo            OK              0.01s
  5/9 test_array                   OK              0.01s
  6/9 test_size_utils              OK              0.01s
  7/9 test_query                   OK              0.02s
  8/9 test_string_utils            OK              0.01s
  9/9 test_time_utils              OK              0.01s
  
  Ok:                9
  Fail:              0
  ```
- [x] Confirmed `ninja -C builddir/ fsearch-pot` removes the author name from .pot file
  ```diff
  -#. Translators: please do NOT translate this.
  -#: data/io.github.cboxdoerfer.FSearch.metainfo.xml.in:73
  -msgid "Christian Boxdörfer"
  -msgstr ""
  ```
