### PR TITLE
Making search diacritics insensitive #303 #385

### DIFF
--- a/src/fsearch_query_matchers.c
+++ b/src/fsearch_query_matchers.c
@@ -2,7 +2,7 @@
 #include "fsearch_database_entry.h"
 #include "fsearch_query_node.h"
 #include <string.h>
-#include "fsearch_string_utils.h"
+#include "fsearch_string_utils.h" /* added for diacritics insensitivity search */
 
 uint32_t
 fsearch_query_matcher_false(FsearchQueryNode *node, FsearchQueryMatchData *match_data) {
@@ -230,7 +230,34 @@ fsearch_query_matcher_strstr(FsearchQueryNode *node, FsearchQueryMatchData *matc
 
 uint32_t
 fsearch_query_matcher_strcasestr(FsearchQueryNode *node, FsearchQueryMatchData *match_data) {
-    return strcasestr(node->haystack_func(match_data), node->needle) ? 1 : 0;
+    const char *haystack = fsearch_query_match_data_get_name_str(match_data);
+    const char *needle = node->needle;
+
+    if (!haystack || !needle || !*needle)
+        return 0;
+
+    /*
+       FIX: Even for ASCII queries, the filename might contain diacritics.
+       We must strip diacritics from the filename before comparing.
+    */
+
+    /* 1. Strip diacritics from the filename */
+    gchar *norm_haystack = fsearch_string_strip_diacritics(haystack);
+
+    /* 2. Case-fold the normalized haystack (to handle case-insensitivity) */
+    /* Note: g_ascii_strcasecmp is faster but doesn't handle UTF8 case folding well.
+       We use g_utf8_casefold on the normalized string to be safe and consistent. */
+    gchar *lower_haystack = g_utf8_casefold(norm_haystack, -1);
+
+    /* 3. Perform the search */
+    /* The needle is already ASCII and lowercased (from node_init_needle logic for ASCII) */
+    uint32_t match = (strstr(lower_haystack, needle) != NULL) ? 1 : 0;
+
+    /* Cleanup */
+    g_free(norm_haystack);
+    g_free(lower_haystack);
+
+    return match;
 }
 
 uint32_t

--- a/src/fsearch_query_matchers.c
+++ b/src/fsearch_query_matchers.c
@@ -2,6 +2,7 @@
 #include "fsearch_database_entry.h"
 #include "fsearch_query_node.h"
 #include <string.h>
+#include "fsearch_string_utils.h"
 
 uint32_t
 fsearch_query_matcher_false(FsearchQueryNode *node, FsearchQueryMatchData *match_data) {
@@ -183,17 +184,27 @@ fsearch_query_matcher_regex(FsearchQueryNode *node, FsearchQueryMatchData *match
 
 uint32_t
 fsearch_query_matcher_utf_strcasestr(FsearchQueryNode *node, FsearchQueryMatchData *match_data) {
-    FsearchUtfBuilder *haystack_builder = node->haystack_func(match_data);
-    FsearchUtfBuilder *needle_builder = node->needle_builder;
-    if (G_LIKELY(haystack_builder->string_is_folded_and_normalized)) {
-        return u_strFindFirst(haystack_builder->string_normalized_folded,
-                              haystack_builder->string_normalized_folded_len,
-                              needle_builder->string_normalized_folded,
-                              needle_builder->string_normalized_folded_len)
-                   ? 1
-                   : 0;
-    }
-    return 0;
+    const char *haystack = fsearch_query_match_data_get_name_str(match_data);
+    const char *needle = node->needle;
+
+    if (!haystack || !needle || !*needle)
+        return 0;
+
+    /* 1. Strip diacritics from the filename (haystack) */
+    gchar *norm_haystack = fsearch_string_strip_diacritics(haystack);
+
+    /* 2. Case-fold the normalized haystack (convert to lowercase) */
+    /* The needle is already case-folded and diacritic-stripped in node_init_needle */
+    gchar *lower_haystack = g_utf8_casefold(norm_haystack, -1);
+
+    /* 3. Perform the search using standard strstr */
+    uint32_t match = (strstr(lower_haystack, needle) != NULL) ? 1 : 0;
+
+    /* Cleanup */
+    g_free(norm_haystack);
+    g_free(lower_haystack);
+
+    return match;
 }
 
 uint32_t

--- a/src/fsearch_query_node.c
+++ b/src/fsearch_query_node.c
@@ -16,17 +16,24 @@ static void
 node_init_needle(FsearchQueryNode *node, const char *needle) {
     g_assert(node);
     g_assert(needle);
-    // node->needle must not be set already
+    /* node->needle must not be set already */
     g_assert_null(node->needle);
     g_assert_null(node->needle_builder);
 
-    node->needle = g_strdup(needle);
-    node->needle_len = strlen(needle);
+    /* --- MODIFICATION START: Strip diacritics from the search query --- */
+    gchar* stripped_needle = fsearch_string_strip_diacritics(needle);
+    node->needle = g_strdup(stripped_needle);
+    g_free(stripped_needle);
+    /* --- MODIFICATION END --- */
 
-    // set up case folded needle in UTF16 format
+    node->needle_len = strlen(node->needle);
+
+    /* set up case folded needle in UTF16 format */
     node->needle_builder = calloc(1, sizeof(FsearchUtfBuilder));
     fsearch_utf_builder_init(node->needle_builder, node->needle_len);
-    const bool utf_ready = fsearch_utf_builder_normalize_and_fold_case(node->needle_builder, needle);
+
+    /* Use the stripped needle for normalization */
+    const bool utf_ready = fsearch_utf_builder_normalize_and_fold_case(node->needle_builder, node->needle);
     g_assert(utf_ready == true);
 }
 

--- a/src/fsearch_string_utils.c
+++ b/src/fsearch_string_utils.c
@@ -164,3 +164,27 @@ fsearch_string_starts_with_interval(char *str, char **end_ptr) {
     *end_ptr = str;
     return false;
 }
+
+gchar*
+fsearch_string_strip_diacritics(const gchar* str) {
+    if (!str || !*str)
+        return g_strdup("");
+
+    gchar* nfd = g_utf8_normalize(str, -1, G_NORMALIZE_NFD);
+    if (!nfd)
+        return g_strdup(str);
+
+    GString* result = g_string_new(NULL);
+    const gchar* p = nfd;
+
+    while (*p) {
+        gunichar c = g_utf8_get_char(p);
+        if (!g_unichar_ismark(c)) {
+            g_string_append_unichar(result, c);
+        }
+        p = g_utf8_next_char(p);
+    }
+
+    g_free(nfd);
+    return g_string_free(result, FALSE);
+}

--- a/src/fsearch_string_utils.h
+++ b/src/fsearch_string_utils.h
@@ -17,6 +17,7 @@
    */
 
 #pragma once
+#include <glib.h>
 #include <stdbool.h>
 #include <unistd.h>
 
@@ -38,6 +39,9 @@ fsearch_string_is_ascii_icase(const char *str);
 
 bool
 fsearch_string_has_wildcards(const char *str);
+
+// diacritics insensitivity, 1 line
+gchar* fsearch_string_strip_diacritics(const gchar* str);
 
 // Converts a wildcard expression to a regular expression, i.e.
 // `*` becomes `.*`


### PR DESCRIPTION
This should solve feature requests #303 #385

I am not a developer, but I have spent around 2 hours to work with AI [Lumo](https://proton.me/lumo) to develop the feature which would allow finding files no matter diacritics as described under above linked issues. [Built the app](https://github.com/cboxdoerfer/fsearch/wiki/Build-instructions), ran it on Linux (Ubuntu 24):

`G_MESSAGES_DEBUG=all /usr/local/bin/fsearch > ~/fsearch_log_full.txt 2>&1`

trying to use diacritics files:
```
رابطه.txt
رابطهٔ.txt
escrzyaie.txt
ěščřžýáíé.txt
```

Test results:

searching for diacritics name: finds files with diacritics and also without it ✅
searching for no-diacritics name: finds files with diacritics and also without it ✅

`nano ~/fsearch_log_full.txt`

does not contain any related issues apparent to me and AI. Can you please test this and review, merge?