### PR TITLE
feat: decouple window and column dimensions in config

### DIFF
--- a/src/fsearch_config.c
+++ b/src/fsearch_config.c
@@ -95,8 +95,6 @@ static const FsearchKeyData SEARCH_SECTION[] = {
 
 static const FsearchKeyData WINDOW_SECTION[] = {
     CONF_BOOL(restore_window_size, true),
-    CONF_INT(window_width, 850),
-    CONF_INT(window_height, 600),
 };
 
 static const FsearchKeyData APPLICATIONS_SECTION[] = {
@@ -130,6 +128,11 @@ static const FsearchKeyData INTERFACE_SECTION[] = {
     CONF_BOOL(show_modified_column, true),
     CONF_BOOL(sort_ascending, true),
     CONF_STR(sort_by, "Name"),
+};
+
+static const FsearchKeyData CACHE_WINDOW_SECTION[] = {
+    CONF_INT(window_width, 850),
+    CONF_INT(window_height, 600),
     CONF_INT(name_column_width, 250),
     CONF_INT(path_column_width, 250),
     CONF_INT(type_column_width, 100),
@@ -202,6 +205,7 @@ static const FsearchKeyData EXCLUDE_KEYS[] = {
 };
 
 static const char *config_file_name = "fsearch.conf";
+static const char *cache_file_name = "window.conf";
 static const char *config_folder_name = "fsearch";
 
 void
@@ -220,11 +224,34 @@ config_build_path(char *path, size_t len) {
     snprintf(path, len, "%s/%s/%s", xdg_conf_dir, config_folder_name, config_file_name);
 }
 
+static void
+config_build_cache_dir(char *path, size_t len) {
+    g_assert(path);
+
+    const gchar *xdg_cache_dir = g_get_user_cache_dir();
+    snprintf(path, len, "%s/%s", xdg_cache_dir, config_folder_name);
+}
+
+static void
+config_build_cache_path(char *path, size_t len) {
+    g_assert(path);
+
+    const gchar *xdg_cache_dir = g_get_user_cache_dir();
+    snprintf(path, len, "%s/%s/%s", xdg_cache_dir, config_folder_name, cache_file_name);
+}
+
 bool
 config_make_dir(void) {
     gchar config_dir[PATH_MAX] = "";
     config_build_dir(config_dir, sizeof(config_dir));
     return !g_mkdir_with_parents(config_dir, 0700);
+}
+
+static bool
+config_make_cache_dir(void) {
+    gchar cache_dir[PATH_MAX] = "";
+    config_build_cache_dir(cache_dir, sizeof(cache_dir));
+    return !g_mkdir_with_parents(cache_dir, 0700);
 }
 
 static void
@@ -631,6 +658,21 @@ config_load(FsearchConfig *config) {
         // Window
         CONFIG_LOAD_SECTION(key_file, "Interface", WINDOW_SECTION, config);
 
+        // Volatile window and column geometry
+        g_autoptr(GKeyFile) cache_key_file = g_key_file_new();
+        g_assert(cache_key_file);
+
+        gchar cache_path[PATH_MAX] = "";
+        config_build_cache_path(cache_path, sizeof(cache_path));
+
+        g_autoptr(GError) cache_error = NULL;
+        if (g_key_file_load_from_file(cache_key_file, cache_path, G_KEY_FILE_NONE, &cache_error)) {
+            CONFIG_LOAD_SECTION(cache_key_file, "Window", CACHE_WINDOW_SECTION, config);
+        }
+        else {
+            CONFIG_LOAD_SECTION(key_file, "Interface", CACHE_WINDOW_SECTION, config);
+        }
+
         // Columns
         if (!config->restore_column_config) {
             config->show_listview_icons = true;
@@ -682,6 +724,7 @@ config_load_default(FsearchConfig *config) {
 
     CONFIG_DEFAULT_SECTION(INTERFACE_SECTION, config);
     CONFIG_DEFAULT_SECTION(WINDOW_SECTION, config);
+    CONFIG_DEFAULT_SECTION(CACHE_WINDOW_SECTION, config);
     CONFIG_DEFAULT_SECTION(DIALOG_SECTION, config);
     CONFIG_DEFAULT_SECTION(APPLICATIONS_SECTION, config);
     CONFIG_DEFAULT_SECTION(SEARCH_SECTION, config);
@@ -804,6 +847,38 @@ config_save(FsearchConfig *config) {
 
     // Excludes
     config_save_excludes(key_file, config->excludes);
+
+    // Volatile window and column geometry is persisted to a separate file in the
+    // cache directory so it doesn't pollute the main settings file (#659). If that
+    // write fails (e.g. the cache dir is unwritable), fall back to storing the
+    // geometry in the main config file under "Interface" so it isn't lost; the next
+    // load picks it back up via the legacy migration path.
+    bool cache_saved = false;
+    g_autoptr(GKeyFile) cache_key_file = g_key_file_new();
+    g_assert(cache_key_file);
+
+    CONFIG_SAVE_SECTION(cache_key_file, "Window", CACHE_WINDOW_SECTION, config);
+
+    if (config_make_cache_dir()) {
+        gchar cache_path[PATH_MAX] = "";
+        config_build_cache_path(cache_path, sizeof(cache_path));
+
+        g_autoptr(GError) cache_error = NULL;
+        if (g_key_file_save_to_file(cache_key_file, cache_path, &cache_error)) {
+            cache_saved = true;
+        }
+        else {
+            g_debug("[config] saving window cache failed: %s", cache_error ? cache_error->message : "unknown error");
+        }
+    }
+    else {
+        g_debug("[config] creating window cache directory failed");
+    }
+
+    if (!cache_saved) {
+        // Fallback: keep geometry in the main config file so it survives.
+        CONFIG_SAVE_SECTION(key_file, "Interface", CACHE_WINDOW_SECTION, config);
+    }
 
     gchar config_path[PATH_MAX] = "";
     config_build_path(config_path, sizeof(config_path));

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -5,6 +5,7 @@ test_string_utils = executable('test_string_utils', 'test_string_utils.c', depen
 test_time_utils = executable('test_time_utils', 'test_time_utils.c', dependencies: libfsearch_dep)
 test_database_include = executable('test_database_include', 'test_database_include.c', dependencies : libfsearch_dep)
 test_database_exclude = executable('test_database_exclude', 'test_database_exclude.c', dependencies : libfsearch_dep)
+test_config = executable('test_config', 'test_config.c', dependencies : libfsearch_dep)
 
 test('test_database_include',
      test_database_include,
@@ -15,6 +16,13 @@ test('test_database_include',
 )
 test('test_database_exclude',
      test_database_exclude,
+     env : [
+         'G_TEST_SRCDIR=@0@'.format(meson.current_source_dir()),
+         'G_TEST_BUILDDIR=@0@'.format(meson.current_build_dir()),
+     ],
+)
+test('test_config',
+     test_config,
      env : [
          'G_TEST_SRCDIR=@0@'.format(meson.current_source_dir()),
          'G_TEST_BUILDDIR=@0@'.format(meson.current_build_dir()),

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -1,0 +1,241 @@
+#include "fsearch_config.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <stdio.h>
+
+typedef struct {
+    char *config_home;
+    char *cache_home;
+    char *config_dir;
+    char *cache_dir;
+    char *config_path;
+    char *cache_path;
+} TestConfigDirs;
+
+static void
+test_config_dirs_init(TestConfigDirs *dirs) {
+    g_assert(dirs);
+
+    g_autoptr(GError) error = NULL;
+
+    dirs->config_home = g_dir_make_tmp("fsearch-config-test-config-XXXXXX", &error);
+    g_assert_no_error(error);
+    g_assert_nonnull(dirs->config_home);
+
+    dirs->cache_home = g_dir_make_tmp("fsearch-config-test-cache-XXXXXX", &error);
+    g_assert_no_error(error);
+    g_assert_nonnull(dirs->cache_home);
+
+    g_setenv("XDG_CONFIG_HOME", dirs->config_home, TRUE);
+    g_setenv("XDG_CACHE_HOME", dirs->cache_home, TRUE);
+
+    dirs->config_dir = g_build_filename(dirs->config_home, "fsearch", NULL);
+    dirs->cache_dir = g_build_filename(dirs->cache_home, "fsearch", NULL);
+    dirs->config_path = g_build_filename(dirs->config_dir, "fsearch.conf", NULL);
+    dirs->cache_path = g_build_filename(dirs->cache_dir, "window.conf", NULL);
+}
+
+static void
+test_config_dirs_clear(TestConfigDirs *dirs) {
+    g_assert(dirs);
+
+    if (dirs->config_path) {
+        g_remove(dirs->config_path);
+    }
+    if (dirs->cache_path) {
+        g_remove(dirs->cache_path);
+    }
+    if (dirs->config_dir) {
+        g_rmdir(dirs->config_dir);
+    }
+    if (dirs->cache_dir) {
+        g_rmdir(dirs->cache_dir);
+    }
+    if (dirs->config_home) {
+        g_rmdir(dirs->config_home);
+    }
+    if (dirs->cache_home) {
+        g_rmdir(dirs->cache_home);
+    }
+
+    g_clear_pointer(&dirs->config_home, g_free);
+    g_clear_pointer(&dirs->cache_home, g_free);
+    g_clear_pointer(&dirs->config_dir, g_free);
+    g_clear_pointer(&dirs->cache_dir, g_free);
+    g_clear_pointer(&dirs->config_path, g_free);
+    g_clear_pointer(&dirs->cache_path, g_free);
+}
+
+static void
+assert_config_key_present(const char *path, const char *group, const char *key) {
+    g_autoptr(GKeyFile) key_file = g_key_file_new();
+    g_autoptr(GError) error = NULL;
+
+    const gboolean loaded = g_key_file_load_from_file(key_file, path, G_KEY_FILE_NONE, &error);
+    g_assert_no_error(error);
+    g_assert_true(loaded);
+    g_assert_true(g_key_file_has_key(key_file, group, key, NULL));
+}
+
+static void
+assert_config_key_absent(const char *path, const char *group, const char *key) {
+    g_autoptr(GKeyFile) key_file = g_key_file_new();
+    g_autoptr(GError) error = NULL;
+
+    const gboolean loaded = g_key_file_load_from_file(key_file, path, G_KEY_FILE_NONE, &error);
+    g_assert_no_error(error);
+    g_assert_true(loaded);
+    g_assert_false(g_key_file_has_key(key_file, group, key, NULL));
+}
+
+static void
+test_config_geometry_round_trip_impl(void) {
+    TestConfigDirs dirs = {};
+    test_config_dirs_init(&dirs);
+
+    g_assert_true(config_make_dir());
+
+    FsearchConfig *config = g_new0(FsearchConfig, 1);
+    g_assert_true(config_load_default(config));
+
+    config->window_width = 1234;
+    config->window_height = 567;
+    config->name_column_width = 999;
+    config->name_column_pos = 4;
+
+    g_assert_true(config_save(config));
+
+    assert_config_key_absent(dirs.config_path, "Interface", "window_width");
+    assert_config_key_absent(dirs.config_path, "Interface", "name_column_width");
+    assert_config_key_present(dirs.cache_path, "Window", "window_width");
+    assert_config_key_present(dirs.cache_path, "Window", "name_column_width");
+
+    FsearchConfig *loaded = g_new0(FsearchConfig, 1);
+    g_assert_true(config_load(loaded));
+
+    g_assert_cmpint(loaded->window_width, ==, 1234);
+    g_assert_cmpint(loaded->window_height, ==, 567);
+    g_assert_cmpuint(loaded->name_column_width, ==, 999);
+    g_assert_cmpuint(loaded->name_column_pos, ==, 4);
+
+    config_free(loaded);
+    config_free(config);
+    test_config_dirs_clear(&dirs);
+}
+
+static void
+test_config_geometry_round_trip(void) {
+    if (g_test_subprocess()) {
+        test_config_geometry_round_trip_impl();
+        return;
+    }
+
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_passed();
+}
+
+static void
+test_config_geometry_migration_impl(void) {
+    TestConfigDirs dirs = {};
+    test_config_dirs_init(&dirs);
+
+    g_assert_cmpint(g_mkdir_with_parents(dirs.config_dir, 0700), ==, 0);
+
+    g_autoptr(GKeyFile) legacy_key_file = g_key_file_new();
+    g_key_file_set_boolean(legacy_key_file, "Interface", "restore_window_size", TRUE);
+    g_key_file_set_integer(legacy_key_file, "Interface", "window_width", 4321);
+    g_key_file_set_integer(legacy_key_file, "Interface", "name_column_width", 888);
+
+    g_autoptr(GError) error = NULL;
+    const gboolean saved = g_key_file_save_to_file(legacy_key_file, dirs.config_path, &error);
+    g_assert_no_error(error);
+    g_assert_true(saved);
+    g_assert_false(g_file_test(dirs.cache_path, G_FILE_TEST_EXISTS));
+
+    FsearchConfig *config = g_new0(FsearchConfig, 1);
+    g_assert_true(config_load(config));
+    g_assert_cmpint(config->window_width, ==, 4321);
+    g_assert_cmpuint(config->name_column_width, ==, 888);
+
+    g_assert_true(config_save(config));
+
+    assert_config_key_present(dirs.cache_path, "Window", "window_width");
+    assert_config_key_absent(dirs.config_path, "Interface", "window_width");
+    assert_config_key_absent(dirs.config_path, "Interface", "name_column_width");
+
+    config_free(config);
+    test_config_dirs_clear(&dirs);
+}
+
+static void
+test_config_geometry_migration(void) {
+    if (g_test_subprocess()) {
+        test_config_geometry_migration_impl();
+        return;
+    }
+
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_passed();
+}
+
+static void
+test_config_geometry_cache_unwritable_fallback_impl(void) {
+    TestConfigDirs dirs = {};
+    test_config_dirs_init(&dirs);
+
+    g_assert_true(config_make_dir());
+
+    // Make the cache dir unwritable by creating a regular file where the cache
+    // directory would go, so config_make_cache_dir() / the cache write fails.
+    g_autoptr(GError) blocker_error = NULL;
+    g_assert_true(g_file_set_contents(dirs.cache_dir, "not a directory", -1, &blocker_error));
+    g_assert_no_error(blocker_error);
+
+    FsearchConfig *config = g_new0(FsearchConfig, 1);
+    g_assert_true(config_load_default(config));
+
+    config->window_width = 1357;
+    config->name_column_width = 246;
+
+    // Main save still succeeds even though the cache write cannot.
+    g_assert_true(config_save(config));
+    g_assert_false(g_file_test(dirs.cache_path, G_FILE_TEST_EXISTS));
+
+    // Geometry is preserved in the main config file as a fallback.
+    assert_config_key_present(dirs.config_path, "Interface", "window_width");
+    assert_config_key_present(dirs.config_path, "Interface", "name_column_width");
+
+    // Remove the blocker so the geometry can be loaded back via the migration path.
+    g_remove(dirs.cache_dir);
+
+    FsearchConfig *loaded = g_new0(FsearchConfig, 1);
+    g_assert_true(config_load(loaded));
+    g_assert_cmpint(loaded->window_width, ==, 1357);
+    g_assert_cmpuint(loaded->name_column_width, ==, 246);
+
+    config_free(loaded);
+    config_free(config);
+    test_config_dirs_clear(&dirs);
+}
+
+static void
+test_config_geometry_cache_unwritable_fallback(void) {
+    if (g_test_subprocess()) {
+        test_config_geometry_cache_unwritable_fallback_impl();
+        return;
+    }
+
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_passed();
+}
+
+int
+main(int argc, char *argv[]) {
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/FSearch/config/geometry_round_trip", test_config_geometry_round_trip);
+    g_test_add_func("/FSearch/config/geometry_migration", test_config_geometry_migration);
+    g_test_add_func("/FSearch/config/geometry_cache_unwritable_fallback",
+                    test_config_geometry_cache_unwritable_fallback);
+    return g_test_run();
+}


### PR DESCRIPTION
## Summary

Stores volatile window/column geometry in a separate file under the XDG cache directory (`~/.cache/fsearch/window.conf`) instead of mixing it into the main settings file (`~/.config/fsearch/fsearch.conf`).

## Why this matters (#659)

Users who version-control their dotfiles get noisy git diffs every time they resize the window or a column, because FSearch writes machine-specific geometry into the same file as substantive settings. Other apps (e.g. KeePassXC, cited in the issue) keep essential settings in `~/.config` and volatile layout state in `~/.cache`. The maintainer greenlit this direction ("That's a great idea. Added to the TODO list.").

## Changes

- Moved the volatile geometry keys out of the settings sections into a new `CACHE_WINDOW_SECTION`: `window_width`, `window_height`, and the six `*_column_width` and five `*_column_pos` keys.
- `restore_window_size`, `restore_column_config`, `restore_sort_order`, the `show_*_column` booleans, `sort_by`, and `sort_ascending` stay in the main config file, since those are deliberate user choices rather than machine-specific geometry.
- Added `config_build_cache_path()` / `config_build_cache_dir()` / `config_make_cache_dir()` helpers that mirror the existing config-path helpers but are rooted at `g_get_user_cache_dir()`.
- `config_save()` writes the geometry to a second GKeyFile under `[Window]` in the cache file. The main settings save is unaffected by a cache-write failure.
- `config_load()` reads geometry from `window.conf`. If that file is absent, it falls back to reading legacy geometry keys from the `[Interface]` section of `fsearch.conf`, so existing users keep their layout on first launch after upgrading (one-time migration; the next save relocates it to the cache file).
- Graceful degradation: if the cache directory is unwritable, the geometry is written back into the main config file as a fallback so it is never silently lost; the legacy-load path picks it back up.
- `config_load_default()` applies the geometry defaults.

## Testing

Added `src/tests/test_config.c` (registered in `src/tests/meson.build`) covering:
- Round-trip: after save, `fsearch.conf` contains no `window_width`/`*_column_width` keys while `window.conf` does, and geometry values round-trip through a reload.
- Migration: a pre-existing `fsearch.conf` with legacy `[Interface]` geometry and no `window.conf` loads those values, and a subsequent save relocates them to the cache file.
- Cache-unwritable fallback: when the cache directory cannot be created, the main save still succeeds and geometry is preserved in `fsearch.conf`, then loads back correctly.

All three tests pass locally (built and run against glib-2.0).

Fixes #659

AI was used for assistance.
